### PR TITLE
Fix jekyll liquid syntax error

### DIFF
--- a/GOOGLE_SCHOLAR_INTEGRATION.md
+++ b/GOOGLE_SCHOLAR_INTEGRATION.md
@@ -30,10 +30,12 @@ This Jekyll site now includes automatic Google Scholar statistics fetching funct
 In your Jekyll pages or posts, use the following Liquid tags:
 
 ```liquid
+{% raw %}
 {% assign scholar_stats = site.google_scholar_id | google_scholar_stats %}
 
 - Papers: {% scholar_stat scholar_stats papers %} - Citations: {% scholar_stat scholar_stats citations %} - h-index:
 {% scholar_stat scholar_stats h_index %} - i10-index: {% scholar_stat scholar_stats i10_index %}
+{% endraw %}
 ```
 
 ## Cache Management


### PR DESCRIPTION
Wrap example Liquid tags in `GOOGLE_SCHOLAR_INTEGRATION.md` with `raw` tags to resolve GitHub Pages build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c812ac77-2e14-4dcd-a95c-369ad7da113f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c812ac77-2e14-4dcd-a95c-369ad7da113f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

