### PR TITLE
Update homepage publications from Google Scholar

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Starting version [v0.3.5](https://github.com/alshedivat/al-folio/releases/tag/v0
 
 ## Local setup on Windows
 
-If you are using Windows, it is **highly recommended** to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install), which is a compatibility layer for running Linux on top of Windows. You can follow [these instructions](https://ubuntu.com/tutorials/install-ubuntu-on-wsl2-on-windows-11-with-gui-support) to install WSL and Ubuntu on your machine. You only need to go up to the step 4 of the tutorial (you don't have to enable the optional `systemd` nor the graphical applications), and then you can follow the instructions below to install docker. You can install docker natively on Windows as well, but it has been having some issues as can be seen in [#1540](https://github.com/alshedivat/al-folio/issues/1540), [#2007](https://github.com/alshedivat/al-folio/issues/2007).
+If you are using Windows, it is **highly recommended** to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install), which is a compatibility layer for running Linux on top of Windows. You can follow [these instructions](https://documentation.ubuntu.com/wsl/latest/howto/install-ubuntu-wsl2/) to install WSL and Ubuntu on your machine. You only need to go up to the step 4 of the tutorial (you don't have to enable the optional `systemd` nor the graphical applications), and then you can follow the instructions below to install docker. You can install docker natively on Windows as well, but it has been having some issues as can be seen in [#1540](https://github.com/alshedivat/al-folio/issues/1540), [#2007](https://github.com/alshedivat/al-folio/issues/2007).
 
 ## Local setup using Docker (Recommended)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Starting version [v0.3.5](https://github.com/alshedivat/al-folio/releases/tag/v0
 
 ## Local setup on Windows
 
-If you are using Windows, it is **highly recommended** to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install), which is a compatibility layer for running Linux on top of Windows. You can follow [these instructions](https://documentation.ubuntu.com/wsl/latest/howto/install-ubuntu-wsl2/) to install WSL and Ubuntu on your machine. You only need to go up to the step 4 of the tutorial (you don't have to enable the optional `systemd` nor the graphical applications), and then you can follow the instructions below to install docker. You can install docker natively on Windows as well, but it has been having some issues as can be seen in [#1540](https://github.com/alshedivat/al-folio/issues/1540), [#2007](https://github.com/alshedivat/al-folio/issues/2007).
+If you are using Windows, it is **highly recommended** to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install), which is a compatibility layer for running Linux on top of Windows. You can follow [these instructions](https://learn.microsoft.com/en-us/windows/wsl/install) to install WSL and Ubuntu on your machine. You only need to go up to the step 4 of the tutorial (you don't have to enable the optional `systemd` nor the graphical applications), and then you can follow the instructions below to install docker. You can install docker natively on Windows as well, but it has been having some issues as can be seen in [#1540](https://github.com/alshedivat/al-folio/issues/1540), [#2007](https://github.com/alshedivat/al-folio/issues/2007).
 
 ## Local setup using Docker (Recommended)
 

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -5,16 +5,16 @@
   title={ WorldRFT: Latent world model planning with reinforcement fine-tuning for autonomous driving },
   author={ P Yang, B Lu, Z Xia, C Han, Y Gao, T Zhang, K Zhan, XP Lang, Y Zheng, ... },
   year={ 2026 },
-  note={ Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649… [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555 },
+  note={ Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649… [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:hC7cP41nSMkC },
   google_scholar_id={ hC7cP41nSMkC },
 }
 
 @misc{unifyinglanguage2026,
-  title={ Unifying Language-Action Understanding and Generation for Autonomous Driving },
+  title={ Unifying language-action understanding and generation for autonomous driving },
   author={ X Wang, Q Liu, W Ding, Z Yang, W Li, C Liu, B Li, K Zhan, X Lang, ... },
   year={ 2026 },
-  note={ arXiv preprint arXiv:2603.01441 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  note={ arXiv preprint arXiv:2603.01441 [2](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14545021791743234404 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:e5wmG9Sq2KIC },
   google_scholar_id={ e5wmG9Sq2KIC },
 }
@@ -32,16 +32,35 @@
   title={ StreamingClaw Technical Report },
   author={ J Chen, Z Chen, C Du, M He, W He, H Li, Q Li, Z Liu, H Ma, X Pan, C Ren, ... },
   year={ 2026 },
-  note={ arXiv preprint arXiv:2603.22120 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  note={ arXiv preprint arXiv:2603.22120 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14090650148033921883 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:RHpTSmoSYBkC },
   google_scholar_id={ RHpTSmoSYBkC },
+}
+
+@misc{rlgf2025,
+  title={ Rlgf: Reinforcement learning with geometric feedback for autonomous driving video generation },
+  author={ T Yan, W Han, X Zhang, K Zhan, CZ Xu, J Shen },
+  year={ 2026 },
+  note={ Advances in Neural Information Processing Systems 38, 128659-128684 [8](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917 },
+  html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC },
+  doi={ 10.48550/arXiv.2509.16500 },
+  google_scholar_id={ 4DMP91E08xMC },
+}
+
+@misc{reflectdrive22026,
+  title={ ReflectDrive-2: Reinforcement-Learning-Aligned Self-Editing for Discrete Diffusion Driving },
+  author={ H Wang, Y Wang, B Cui, P Li, B Lu, M Wang, T Wang, C Tang, T Zhang, ... },
+  year={ 2026 },
+  note={ arXiv preprint arXiv:2605.04647 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC },
+  google_scholar_id={ bEWYMUwI8FkC },
 }
 
 @misc{planagent2024,
   title={ Planagent: A multi-modal large language agent for closed-loop vehicle motion planning },
   author={ Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao },
   year={ 2026 },
-  note={ IEEE Transactions on Cognitive and Developmental Systems [55](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257 },
+  note={ IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC },
   google_scholar_id={ Tyk-4Ss8FVUC },
 }
@@ -53,6 +72,15 @@
   note={ US Patent App. 19/037,583 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:-f6ydRqryjwC },
   google_scholar_id={ -f6ydRqryjwC },
+}
+
+@misc{m2asynergizing2026,
+  title={ M2A: Synergizing Mathematical and Agentic Reasoning in Large Language Models },
+  author={ J Wang, X Zhou, Q Xu, K Zhan },
+  year={ 2026 },
+  note={ arXiv preprint arXiv:2605.09879 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C },
+  google_scholar_id={ iH-uZ7U-co4C },
 }
 
 @misc{hardwareco2026,
@@ -77,7 +105,7 @@
   title={ Evolving from Tool User to Creator via Training-Free Experience Reuse in Multimodal Reasoning },
   author={ X Shen, J Chen, L Zheng, H Ma, T Wei, K Zhan },
   year={ 2026 },
-  note={ arXiv preprint arXiv:2602.01983 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910 },
+  note={ arXiv preprint arXiv:2602.01983 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:hFOr9nPyWt4C },
   google_scholar_id={ hFOr9nPyWt4C },
 }
@@ -119,11 +147,20 @@
   google_scholar_id={ 7PzlFSSx8tAC },
 }
 
+@misc{closedloop2026,
+  title={ Closed Loop Dynamic Driving Data Mixture for Real-Synthetic Co-Training },
+  author={ H Ruan, P Liu, W Ma, Z Li, X Zhang, J Ma, D Xu, K Zhan },
+  year={ 2026 },
+  note={ arXiv preprint arXiv:2605.21372 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC },
+  google_scholar_id={ TFP_iSt0sucC },
+}
+
 @misc{transdiffuser2025,
   title={ Transdiffuser: End-to-end trajectory generation with decorrelated multi-modal representation for autonomous driving },
   author={ X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, XP Lang, S Sun },
   year={ 2025 },
-  note={ arXiv e-prints, arXiv: 2505.09315 [21](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773 },
+  note={ arXiv e-prints, arXiv: 2505.09315 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:Zph67rFs4hoC },
   google_scholar_id={ Zph67rFs4hoC },
 }
@@ -141,7 +178,7 @@
   title={ The better you learn, the smarter you prune: Towards efficient vision-language-action models via differentiable token pruning },
   author={ T Jiang, X Jiang, Y Ma, X Wen, B Li, K Zhan, P Jia, Y Liu, S Sun, X Lang },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2509.12594 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439 },
+  note={ arXiv preprint arXiv:2509.12594 [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:aqlVkmm33-oC },
   google_scholar_id={ aqlVkmm33-oC },
 }
@@ -159,7 +196,7 @@
   title={ Streetcrafter: Street view synthesis with controllable video diffusion models },
   author={ Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou, ... },
   year={ 2025 },
-  note={ Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832 [43](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678 },
+  note={ Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832 [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC },
   google_scholar_id={ Se3iqnhoufwC },
 }
@@ -192,21 +229,11 @@
   google_scholar_id={ _kc_bZDykSQC },
 }
 
-@misc{rlgf2025,
-  title={ Rlgf: Reinforcement learning with geometric feedback for autonomous driving video generation },
-  author={ T Yan, W Han, X Zhou, X Zhang, K Zhan, C Xu, J Shen },
-  year={ 2025 },
-  note={ arXiv preprint arXiv:2509.16500 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917 },
-  html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC },
-  doi={ 10.48550/arXiv.2509.16500 },
-  google_scholar_id={ 4DMP91E08xMC },
-}
-
 @misc{recondreamer2025,
   title={ Recondreamer: Crafting world models for driving scene reconstruction via online restoration },
   author={ C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ... },
   year={ 2025 },
-  note={ Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569 [86](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982 },
+  note={ Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569 [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC },
   google_scholar_id={ LkGwnXOMwfcC },
 }
@@ -224,7 +251,7 @@
   title={ Omnigen: Unified multimodal sensor generation for autonomous driving },
   author={ T Tang, E Ma, X Zhou, L Wang, T Yan, X Zhang, K Zhan, P Jia, X Lang, ... },
   year={ 2025 },
-  note={ Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086 },
+  note={ Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:mVmsd5A6BfQC },
   doi={ 10.48550/arXiv.2512.14225 },
   google_scholar_id={ mVmsd5A6BfQC },
@@ -234,7 +261,7 @@
   title={ Learning Personalized Driving Styles via Reinforcement Learning from Human Feedback },
   author={ D Li, C Li, Y Wang, J Ren, X Wen, P Li, L Xu, K Zhan, P Jia, X Lang, N Xu, ... },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2503.10434 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182 },
+  note={ arXiv preprint arXiv:2503.10434 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:mB3voiENLucC },
   google_scholar_id={ mB3voiENLucC },
 }
@@ -252,7 +279,7 @@
   title={ Hierarchy UGP: Hierarchy Unified Gaussian Primitive for Large-Scale Dynamic Scene Reconstruction },
   author={ H Sun, Q Yang, J Wang, Z Xu, C Liu, Y Wang, K Zhan, H Bao, X Zhou, ... },
   year={ 2025 },
-  note={ Proceedings of the IEEE/CVF International Conference on Computer Vision… [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate },
+  note={ Proceedings of the IEEE/CVF International Conference on Computer Vision… [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16823791912791942975 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:QIV2ME_5wuYC },
   google_scholar_id={ QIV2ME_5wuYC },
 }
@@ -261,7 +288,7 @@
   title={ Geodrive: 3d geometry-informed driving world model with precise action control },
   author={ A Chen, W Zheng, Y Wang, X Zhang, K Zhan, P Jia, K Keutzer, S Zhang },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2505.22421 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204 },
+  note={ arXiv preprint arXiv:2505.22421 [16](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:YOwf2qJgpHMC },
   google_scholar_id={ YOwf2qJgpHMC },
 }
@@ -298,7 +325,7 @@
   title={ DriveAgent-R1: Advancing VLM-based autonomous driving with hybrid thinking and active perception },
   author={ W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao },
   year={ 2025 },
-  note={ arXiv e-prints, arXiv: 2507.20879 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899 },
+  note={ arXiv e-prints, arXiv: 2507.20879 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:qxL8FJ1GzNcC },
   google_scholar_id={ qxL8FJ1GzNcC },
 }
@@ -307,7 +334,7 @@
   title={ DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception and Hybrid Thinking },
   author={ W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2507.20879 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237 },
+  note={ arXiv preprint arXiv:2507.20879 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:dhFuZR0502QC },
   google_scholar_id={ dhFuZR0502QC },
 }
@@ -325,7 +352,7 @@
   title={ Discrete diffusion for reflective vision-language-action models in autonomous driving },
   author={ P Li, Y Zheng, Y Wang, H Wang, H Zhao, J Liu, X Zhan, K Zhan, X Lang },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2509.20109 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583 },
+  note={ arXiv preprint arXiv:2509.20109 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:Wp0gIr-vW9MC },
   google_scholar_id={ Wp0gIr-vW9MC },
 }
@@ -334,7 +361,7 @@
   title={ Bev-tsr: Text-scene retrieval in bev space for autonomous driving },
   author={ T Tang, D Wei, Z Jia, T Gao, C Cai, C Hou, P Jia, K Zhan, H Sun, ... },
   year={ 2025 },
-  note={ Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283 [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481 },
+  note={ Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283 [19](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:eQOLeE2rZwMC },
   google_scholar_id={ eQOLeE2rZwMC },
 }
@@ -343,7 +370,7 @@
   title={ AD-R1: Closed-Loop Reinforcement Learning for End-to-End Autonomous Driving with Impartial World Models },
   author={ T Yan, T Tang, X Gui, Y Li, J Zhesng, W Huang, L Kong, W Han, X Zhou, ... },
   year={ 2025 },
-  note={ arXiv preprint arXiv:2511.20325 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649 },
+  note={ arXiv preprint arXiv:2511.20325 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:IWHjjKOFINEC },
   google_scholar_id={ IWHjjKOFINEC },
 }
@@ -352,7 +379,7 @@
   title={ 3drealcar: An in-the-wild rgb-d car dataset with 360-degree views },
   author={ X Du, Y Wang, H Sun, Z Wu, H Sheng, S Wang, J Ying, M Lu, T Zhu, ... },
   year={ 2025 },
-  note={ Proceedings of the IEEE/CVF International Conference on Computer Vision… [25](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905 },
+  note={ Proceedings of the IEEE/CVF International Conference on Computer Vision… [26](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:Y0pCki6q_DkC },
   google_scholar_id={ Y0pCki6q_DkC },
 }
@@ -370,7 +397,7 @@
   title={ Unleashing generalization of end-to-end autonomous driving with controllable long video generation },
   author={ E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ... },
   year={ 2024 },
-  note={ arXiv preprint arXiv:2406.01349 [51](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939 },
+  note={ arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC },
   google_scholar_id={ W7OEmFMy1HYC },
 }
@@ -379,7 +406,7 @@
   title={ Ua-track: Uncertainty-aware end-to-end 3d multi-object tracking },
   author={ L Zhou, T Tang, P Hao, Z He, K Ho, S Gu, W Hou, Z Hao, H Sun, K Zhan, ... },
   year={ 2024 },
-  note={ arXiv e-prints, arXiv: 2406.02147 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580 },
+  note={ arXiv e-prints, arXiv: 2406.02147 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:WF5omc3nYNoC },
   google_scholar_id={ WF5omc3nYNoC },
 }
@@ -388,7 +415,7 @@
   title={ Tod3cap: Towards 3d dense captioning in outdoor scenes },
   author={ B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun, ... },
   year={ 2024 },
-  note={ European Conference on Computer Vision, 367-384 [42](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791 },
+  note={ European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC },
   google_scholar_id={ ufrVoPGSRksC },
 }
@@ -397,7 +424,7 @@
   title={ Street gaussians: Modeling dynamic urban scenes with gaussian splatting },
   author={ Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng },
   year={ 2024 },
-  note={ European Conference on Computer Vision, 156-173 [406](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561 },
+  note={ European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C },
   preview={ /assets/img/publication_preview/street2024-preview.png },
   google_scholar_id={ IjCSPb-OGe4C },
@@ -407,7 +434,7 @@
   title={ S2-track: A simple yet strong approach for end-to-end 3d multi-object tracking },
   author={ T Tang, L Zhou, P Hao, Z He, K Ho, S Gu, Z Hao, H Sun, K Zhan, P Jia, ... },
   year={ 2024 },
-  note={ arXiv preprint arXiv:2406.02147 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409 },
+  note={ arXiv preprint arXiv:2406.02147 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:ULOm3_A8WrAC },
   google_scholar_id={ ULOm3_A8WrAC },
 }
@@ -416,7 +443,7 @@
   title={ Drivevlm: The convergence of autonomous driving and large vision-language models },
   author={ X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao },
   year={ 2024 },
-  note={ arXiv preprint arXiv:2402.12289 [562](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041 },
+  note={ arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC },
   thumbnail={ /assets/img/publication_preview/drivevlm2024.png },
   google_scholar_id={ zYLM7Y9cAGgC },
@@ -426,7 +453,7 @@
   title={ Dive: Dit-based video generation with enhanced control },
   author={ J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun, ... },
   year={ 2024 },
-  note={ arXiv preprint arXiv:2409.01595 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597 },
+  note={ arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C },
   google_scholar_id={ YsMSGLbcyi4C },
 }
@@ -443,7 +470,7 @@
   title={ Balanced 3DGS: Gaussian-wise parallelism rendering with fine-grained tiling },
   author={ H Gui, L Hu, R Chen, M Huang, Y Yin, J Yang, Y Wu, C Liu, Z Sun, ... },
   year={ 2024 },
-  note={ arXiv preprint arXiv:2412.17378 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687 },
+  note={ arXiv preprint arXiv:2412.17378 [13](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687 },
   html={ https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&pagesize=100&sortby=pubdate&citation_for_view=1J061HIAAAAJ:roLk4NBRz8UC },
   google_scholar_id={ roLk4NBRz8UC },
 }

--- a/_data/scholar.yml
+++ b/_data/scholar.yml
@@ -3,906 +3,946 @@ profile:
   citations: 1335
   h_index: 15
   i10_index: 21
-  updated_at: "2026-04-27T12:52:12Z"
+  updated_at: '2026-05-27T12:24:48Z'
 publications:
-  - key: drivevlm2024
-    title: "Drivevlm: The convergence of autonomous driving and large vision-language
-      models"
-    authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
-    year: "2024"
-    venue: arXiv preprint arXiv:2402.12289 [562](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
-    citation_count: 562
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
-    external_url: https://arxiv.org/abs/2402.12289
-    pdf_url: https://arxiv.org/pdf/2402.12289
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/drivevlm2024.png
-    google_scholar_id: zYLM7Y9cAGgC
-  - key: street2024
-    title: "Street gaussians: Modeling dynamic urban scenes with gaussian splatting"
-    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-    year: "2024"
-    venue: European Conference on Computer Vision, 156-173 [406](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
-    citation_count: 406
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
-    external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
-    pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/street2024-preview.png
-    google_scholar_id: IjCSPb-OGe4C
-  - key: recondreamer2025
-    title: "Recondreamer: Crafting world models for driving scene reconstruction via
-      online restoration"
-    authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
-      [86](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
-    citation_count: 86
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: LkGwnXOMwfcC
-  - key: planagent2024
-    title: "Planagent: A multi-modal large language agent for closed-loop vehicle motion
-      planning"
-    authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
-    year: "2026"
-    venue: IEEE Transactions on Cognitive and Developmental Systems [55](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
-    citation_count: 55
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
-    external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
-    pdf_url: https://arxiv.org/pdf/2406.01587
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: Tyk-4Ss8FVUC
-  - key: unleashing2024
-    title: Unleashing generalization of end-to-end autonomous driving with controllable
-      long video generation
-    authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2406.01349 [51](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
-    citation_count: 51
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
-    external_url: https://arxiv.org/abs/2406.01349
-    pdf_url: https://arxiv.org/pdf/2406.01349
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: W7OEmFMy1HYC
-  - key: streetcrafter2025
-    title: "Streetcrafter: Street view synthesis with controllable video diffusion models"
-    authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
-      ...
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
-      [43](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
-    citation_count: 43
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: Se3iqnhoufwC
-  - key: tod3cap2024
-    title: "Tod3cap: Towards 3d dense captioning in outdoor scenes"
-    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-      ...
-    year: "2024"
-    venue: European Conference on Computer Vision, 367-384 [42](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
-    citation_count: 42
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
-    external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
-    pdf_url: https://arxiv.org/pdf/2403.19589?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: ufrVoPGSRksC
-  - key: drivingsphere2025
-    title: "Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation"
-    authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
-      [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
-    citation_count: 32
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: UebtZRa9Y70C
-  - key: finetuning2025
-    title: Finetuning generative trajectory model with reinforcement learning from human
-      feedback
-    authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
-      Xu, ...
-    year: "2025"
-    venue: "arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741"
-    citation_count: 31
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
-    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/finetuning2025-preview.png
-    google_scholar_id: MXK_kJrjxJIC
-  - key: dive2024
-    title: "Dive: Dit-based video generation with enhanced control"
-    authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
-      ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2409.01595 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
-    citation_count: 31
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
-    external_url: https://arxiv.org/abs/2409.01595
-    pdf_url: https://arxiv.org/pdf/2409.01595
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: YsMSGLbcyi4C
-  - key: 3drealcar2024
-    title: "3drealcar: An in-the-wild rgb-d car dataset with 360-degree views"
-    authors: X Du, Y Wang, H Sun, Z Wu, H Sheng, S Wang, J Ying, M Lu, T Zhu, ...
-    year: "2025"
-    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-      [25](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905
-    citation_count: 25
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Y0pCki6q_DkC
-    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: Y0pCki6q_DkC
-  - key: bevclip2024
-    title: "Bev-clip: Multi-modal bev retrieval methodology for complex scene in autonomous
-      driving"
-    authors: Z Jia, T Gao, C Cai, C Hou, P Jia, F JingChen, Y ZHAO, K Zhan, FU LIU,
-      ...[24](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17455078764301502962)2024
-    year: "2024"
-    venue: ""
-    citation_count: 24
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:0EnyYjriUFMC
-    external_url: https://openreview.net/forum?id=wlqkRFRkYc
-    pdf_url: https://openreview.net/pdf?id=wlqkRFRkYc
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 0EnyYjriUFMC
-  - key: generalizing2024
-    title: Generalizing motion planners with mixture of experts for autonomous driving
-    authors: Q Sun, H Wang, J Zhan, F Nie, X Wen, L Xu, K Zhan, P Jia, X Lang, ...
-    year: "2025"
-    venue: IEEE International Conference on Robotics and Automation (ICRA), 6033-6039
-      [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8525832948576027576
-    citation_count: 23
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_FxGoFyzp5QC
-    external_url: https://ieeexplore.ieee.org/abstract/document/11127274/
-    pdf_url: https://arxiv.org/pdf/2410.15774?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: _FxGoFyzp5QC
-  - key: thebetter2025
-    title: "The better you learn, the smarter you prune: Towards efficient vision-language-action
-      models via differentiable token pruning"
-    authors: T Jiang, X Jiang, Y Ma, X Wen, B Li, K Zhan, P Jia, Y Liu, S Sun, X Lang
-    year: "2025"
-    venue: arXiv preprint arXiv:2509.12594 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439
-    citation_count: 22
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:aqlVkmm33-oC
-    external_url: https://arxiv.org/abs/2509.12594
-    pdf_url: https://arxiv.org/pdf/2509.12594?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: aqlVkmm33-oC
-  - key: transdiffuser2025
-    title: "Transdiffuser: End-to-end trajectory generation with decorrelated multi-modal
-      representation for autonomous driving"
-    authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, XP Lang, S Sun
-    year: "2025"
-    venue: "arXiv e-prints, arXiv: 2505.09315 [21](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773"
-    citation_count: 21
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Zph67rFs4hoC
-    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250509315J/abstract
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: Zph67rFs4hoC
-  - key: bevtsr2025
-    title: "Bev-tsr: Text-scene retrieval in bev space for autonomous driving"
-    authors: T Tang, D Wei, Z Jia, T Gao, C Cai, C Hou, P Jia, K Zhan, H Sun, ...
-    year: "2025"
-    venue: Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283
-      [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481
-    citation_count: 17
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:eQOLeE2rZwMC
-    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/32782
-    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/32782/34937
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: eQOLeE2rZwMC
-  - key: joint2015
-    title: Joint tracking and classification with constraints and reassignment by radar
-      and ESM
-    authors: H Jiang, K Zhan, L Xu
-    year: "2015"
-    venue: Digital Signal Processing 40, 213-223 [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2198228601778586949
-    citation_count: 17
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:2osOgNQ5qMEC
-    external_url: https://www.sciencedirect.com/science/article/pii/S105120041500024X
-    pdf_url: https://www.researchgate.net/profile/Kun-Zhan-4/publication/272522907_Joint_tracking_and_classification_with_constraints_and_reassignment_by_radar_and_ESM/links/5dd4aa18458515cd48ac0bc6/Joint-tracking-and-classification-with-constraints-and-reassignment-by-radar-and-ESM.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 2osOgNQ5qMEC
-  - key: geodrive2025
-    title: "Geodrive: 3d geometry-informed driving world model with precise action control"
-    authors: A Chen, W Zheng, Y Wang, X Zhang, K Zhan, P Jia, K Keutzer, S Zhang
-    year: "2025"
-    venue: arXiv preprint arXiv:2505.22421 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204
-    citation_count: 15
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YOwf2qJgpHMC
-    external_url: https://arxiv.org/abs/2505.22421
-    pdf_url: https://arxiv.org/pdf/2505.22421
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: YOwf2qJgpHMC
-  - key: joint2014
-    title: Joint tracking and classification based on aerodynamic model and radar cross
-      section
-    authors: H Jiang, L Xu, K Zhan
-    year: "2014"
-    venue: Pattern recognition 47 (9), 3096-3105 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7434382400669015995
-    citation_count: 15
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qjMakFHDy7sC
-    external_url: https://www.sciencedirect.com/science/article/pii/S0031320314000715
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: qjMakFHDy7sC
-  - key: balanced2024
-    title: "Balanced 3DGS: Gaussian-wise parallelism rendering with fine-grained tiling"
-    authors: H Gui, L Hu, R Chen, M Huang, Y Yin, J Yang, Y Wu, C Liu, Z Sun, ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2412.17378 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687
-    citation_count: 12
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:roLk4NBRz8UC
-    external_url: https://arxiv.org/abs/2412.17378
-    pdf_url: https://arxiv.org/pdf/2412.17378?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: roLk4NBRz8UC
-  - key: street2023
-    title: Street gaussians for modeling dynamic urban scenes.(2023)
-    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-    year: "2023"
-    venue: arXiv preprint arXiv:2401.01339 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2617111234141021442
-    citation_count: 11
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:5nxA0vEk-isC
-    external_url: https://scholar.google.com/scholar?cluster=2617111234141021442&hl=en&oi=scholarr
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 5nxA0vEk-isC
-  - key: worldrftlatent2026
-    title: "WorldRFT: Latent world model planning with reinforcement fine-tuning for
-      autonomous driving"
-    authors: P Yang, B Lu, Z Xia, C Han, Y Gao, T Zhang, K Zhan, XP Lang, Y Zheng, ...
-    year: "2026"
-    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649…
-      [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555
-    citation_count: 10
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hC7cP41nSMkC
-    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/38149
-    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/38149/42111
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: hC7cP41nSMkC
-  - key: discretediffusion2025
-    title: Discrete diffusion for reflective vision-language-action models in autonomous
-      driving
-    authors: P Li, Y Zheng, Y Wang, H Wang, H Zhao, J Liu, X Zhan, K Zhan, X Lang
-    year: "2025"
-    venue: arXiv preprint arXiv:2509.20109 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583
-    citation_count: 10
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Wp0gIr-vW9MC
-    external_url: https://arxiv.org/abs/2509.20109
-    pdf_url: https://arxiv.org/pdf/2509.20109?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: Wp0gIr-vW9MC
-  - key: driveagentr120252
-    title: "DriveAgent-R1: Advancing VLM-based autonomous driving with hybrid thinking
-      and active perception"
-    authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
-    year: "2025"
-    venue: "arXiv e-prints, arXiv: 2507.20879 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899"
-    citation_count: 9
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qxL8FJ1GzNcC
-    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250720879Z/abstract
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: qxL8FJ1GzNcC
-  - key: uatrack2024
-    title: "Ua-track: Uncertainty-aware end-to-end 3d multi-object tracking"
-    authors: L Zhou, T Tang, P Hao, Z He, K Ho, S Gu, W Hou, Z Hao, H Sun, K Zhan, ...
-    year: "2024"
-    venue: "arXiv e-prints, arXiv: 2406.02147 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580"
-    citation_count: 9
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:WF5omc3nYNoC
-    external_url: https://scholar.google.com/scholar?cluster=15720233251267028580&hl=en&oi=scholarr
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: WF5omc3nYNoC
-  - key: dive1961
-    title: "Dive: Efficient multi-view driving scenes generation based on video diffusion
-      transformer"
-    authors: J Jiang, G Hong, M Zhang, H Hu, K Zhan, R Shao, L Nie
-    year: "2025"
-    venue: arXiv preprint arXiv:2504.19614 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17699301463624196526
-    citation_count: 6
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:3fE2CSJIrl8C
-    external_url: https://arxiv.org/abs/2504.19614
-    pdf_url: https://arxiv.org/pdf/2504.19614
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 3fE2CSJIrl8C
-  - key: adr12025
-    title: "AD-R1: Closed-Loop Reinforcement Learning for End-to-End Autonomous Driving
-      with Impartial World Models"
-    authors: T Yan, T Tang, X Gui, Y Li, J Zhesng, W Huang, L Kong, W Han, X Zhou, ...
-    year: "2025"
-    venue: arXiv preprint arXiv:2511.20325 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649
-    citation_count: 6
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IWHjjKOFINEC
-    external_url: https://arxiv.org/abs/2511.20325
-    pdf_url: https://arxiv.org/pdf/2511.20325
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: IWHjjKOFINEC
-  - key: xiaoxiaolong2024
-    title: "Xiaoxiao Long, Yilun Chen, and Hao Zhao. Tod3cap: Towards 3d dense captioning
-      in outdoor scenes"
-    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-      ...
-    year: "2024"
-    venue: Computer Vision–ECCV, 367-384 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7647393139940744594
-    citation_count: 6
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:M3ejUd6NZC8C
-    external_url: https://scholar.google.com/scholar?cluster=7647393139940744594&hl=en&oi=scholarr
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: M3ejUd6NZC8C
-  - key: joint20142
-    title: Joint tracking and classification on aerodynamic model and RCS by ground-based
-      passive radar
-    authors: L Xu, K Zhan, H Jiang, L Bai, M Wu
-    year: "2014"
-    venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
-      [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1850746215740028633
-    citation_count: 6
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:9yKSN-GCB0IC
-    external_url: https://ieeexplore.ieee.org/abstract/document/7007306/
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 9yKSN-GCB0IC
-  - key: robopearls2025
-    title: "RoboPearls: editable video simulation for robot manipulation"
-    authors: T Tao, L Zhang, Y Wen, K Zhang, JW Bian, X Zhou, T Yan, K Zhan, P Jia,
-      ...
-    year: "2025"
-    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-      [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2125478236741172501
-    citation_count: 5
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_kc_bZDykSQC
-    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Tao_RoboPearls_Editable_Video_Simulation_for_Robot_Manipulation_ICCV_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Tao_RoboPearls_Editable_Video_Simulation_for_Robot_Manipulation_ICCV_2025_paper.pdf
-    doi: 10.48550/arXiv.2506.22756
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: _kc_bZDykSQC
-  - key: s2track2024
-    title: "S2-track: A simple yet strong approach for end-to-end 3d multi-object tracking"
-    authors: T Tang, L Zhou, P Hao, Z He, K Ho, S Gu, Z Hao, H Sun, K Zhan, P Jia, ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2406.02147 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409
-    citation_count: 5
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ULOm3_A8WrAC
-    external_url: https://arxiv.org/abs/2406.02147
-    pdf_url: https://arxiv.org/pdf/2406.02147
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: ULOm3_A8WrAC
-  - key: evolvingfrom2026
-    title: Evolving from Tool User to Creator via Training-Free Experience Reuse in
-      Multimodal Reasoning
-    authors: X Shen, J Chen, L Zheng, H Ma, T Wei, K Zhan
-    year: "2026"
-    venue: arXiv preprint arXiv:2602.01983 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910
-    citation_count: 4
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hFOr9nPyWt4C
-    external_url: https://arxiv.org/abs/2602.01983
-    pdf_url: https://arxiv.org/pdf/2602.01983
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: hFOr9nPyWt4C
-  - key: rlgf2025
-    title: "Rlgf: Reinforcement learning with geometric feedback for autonomous driving
-      video generation"
-    authors: T Yan, W Han, X Zhou, X Zhang, K Zhan, C Xu, J Shen
-    year: "2025"
-    venue: arXiv preprint arXiv:2509.16500 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917
-    citation_count: 4
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC
-    external_url: https://arxiv.org/abs/2509.16500
-    pdf_url: https://arxiv.org/pdf/2509.16500
-    doi: 10.48550/arXiv.2509.16500
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 4DMP91E08xMC
-  - key: posepilot2025
-    title: "PosePilot: Steering camera pose for generative world models with self-supervised
-      depth"
-    authors: B Jin, W Li, B Yang, Z Zhu, J Jiang, H Gao, H Sun, K Zhan, H Hu, X Zhang,
-      ...
-    year: "2025"
-    venue: IEEE/RSJ International Conference on Intelligent Robots and Systems… [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10498075774223536829
-    citation_count: 4
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:kNdYIx-mwKoC
-    external_url: https://ieeexplore.ieee.org/abstract/document/11247293/
-    pdf_url: https://arxiv.org/pdf/2505.01729
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: kNdYIx-mwKoC
-  - key: transdiffuserdiverse2025
-    title: "Transdiffuser: Diverse trajectory generation with decorrelated multi-modal
-      representation for end-to-end autonomous driving"
-    authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, X Lang, S Sun
-    year: "2025"
-    venue: arXiv preprint arXiv:2505.09315 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12624178323067622969
-    citation_count: 3
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:HDshCWvjkbEC
-    external_url: https://arxiv.org/abs/2505.09315
-    pdf_url: https://arxiv.org/pdf/2505.09315
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: HDshCWvjkbEC
-  - key: omnigen2025
-    title: "Omnigen: Unified multimodal sensor generation for autonomous driving"
-    authors: T Tang, E Ma, X Zhou, L Wang, T Yan, X Zhang, K Zhan, P Jia, X Lang, ...
-    year: "2025"
-    venue: Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374
-      [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086
-    citation_count: 3
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mVmsd5A6BfQC
-    external_url: https://dl.acm.org/doi/abs/10.1145/3746027.3754772
-    pdf_url: https://dl.acm.org/doi/pdf/10.1145/3746027.3754772
-    doi: 10.48550/arXiv.2512.14225
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: mVmsd5A6BfQC
-  - key: learningpersonalized2025
-    title: Learning Personalized Driving Styles via Reinforcement Learning from Human
-      Feedback
-    authors: D Li, C Li, Y Wang, J Ren, X Wen, P Li, L Xu, K Zhan, P Jia, X Lang, N
-      Xu, ...
-    year: "2025"
-    venue: arXiv preprint arXiv:2503.10434 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182
-    citation_count: 3
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mB3voiENLucC
-    external_url: https://arxiv.org/abs/2503.10434
-    pdf_url: https://arxiv.org/pdf/2503.10434
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: mB3voiENLucC
-  - key: driveagentr12025
-    title: "DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception
-      and Hybrid Thinking"
-    authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
-    year: "2025"
-    venue: arXiv preprint arXiv:2507.20879 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237
-    citation_count: 3
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:dhFuZR0502QC
-    external_url: https://arxiv.org/abs/2507.20879
-    pdf_url: https://arxiv.org/pdf/2507.20879
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: dhFuZR0502QC
-  - key: particle2014
-    title: Particle filter based joint tracking and classification
-    authors: K Zhan, L Xu, H Jiang, L Bai, M Wu
-    year: "2014"
-    venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
-      [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11948931031763077540
-    citation_count: 3
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UeHWp8X0CEIC
-    external_url: https://ieeexplore.ieee.org/abstract/document/7007307/
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: UeHWp8X0CEIC
-  - key: correctada2026
-    title: "Correctad: A self-correcting agentic system to improve end-to-end planning
-      in autonomous driving"
-    authors: E Ma, L Zhou, T Tang, J Zhang, J Jiang, Z Zhang, D Han, K Zhan, X Zhang,
-      ...
-    year: "2026"
-    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (10), 7755-7763
-      [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9391779730238116875
-    citation_count: 1
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:7PzlFSSx8tAC
-    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718
-    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718/41680
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 7PzlFSSx8tAC
-  - key: styledstreets2025
-    title: "StyledStreets: Multi-style Street Simulator with Spatial and Temporal Consistency"
-    authors: Y Chen, Y Wang, X Zhang, K Zhan, P Jia, Y Zhan, X Lang
-    year: "2025"
-    venue: arXiv preprint arXiv:2503.21104 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=36853680135788572
-    citation_count: 1
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hqOjcs7Dif8C
-    external_url: https://arxiv.org/abs/2503.21104
-    pdf_url: https://arxiv.org/pdf/2503.21104?
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: hqOjcs7Dif8C
-  - key: unifyinglanguage2026
-    title: Unifying Language-Action Understanding and Generation for Autonomous Driving
-    authors: X Wang, Q Liu, W Ding, Z Yang, W Li, C Liu, B Li, K Zhan, X Lang, ...
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.01441 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:e5wmG9Sq2KIC
-    external_url: https://arxiv.org/abs/2603.01441
-    pdf_url: https://arxiv.org/pdf/2603.01441
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: e5wmG9Sq2KIC
-  - key: streetforwardperceiving2026
-    title: "StreetForward: Perceiving Dynamic Street with Feedforward Causal Attention"
-    authors: Z Yu, Z Wang, Y Xie, Y Wang, X Zhang, Y Zhan, K Zhan
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.19552 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:j3f4tGmQtD8C
-    external_url: https://arxiv.org/abs/2603.19552
-    pdf_url: https://arxiv.org/pdf/2603.19552
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: j3f4tGmQtD8C
-  - key: streamingclawtechnical2026
-    title: StreamingClaw Technical Report
-    authors: J Chen, Z Chen, C Du, M He, W He, H Li, Q Li, Z Liu, H Ma, X Pan, C Ren,
-      ...
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.22120 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:RHpTSmoSYBkC
-    external_url: https://arxiv.org/abs/2603.22120
-    pdf_url: https://arxiv.org/pdf/2603.22120
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: RHpTSmoSYBkC
-  - key: methodand2026
-    title: Method and apparatus for generating trajectory, electronic device, storage
-      medium
-    authors: B Li, K Zhan, P Jia, X Lang, Y Wang, J GU, Y Jiang, Q Jiang, S Zhao, ...
-    year: "2026"
-    venue: US Patent App. 19/037,583 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:-f6ydRqryjwC
-    external_url: https://patents.google.com/patent/US20260008479A1/en
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: -f6ydRqryjwC
-  - key: hardwareco2026
-    title: Hardware Co-Design Scaling Laws via Roofline Modelling for On-Device LLMs
-    authors: L Sun, J Jiang, Y Ding, F Li, Y Song, H Zhang, J Ying, L Ren, K Zhan, ...
-    year: "2026"
-    venue: arXiv preprint arXiv:2602.10377 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:r0BpntZqJG4C
-    external_url: https://arxiv.org/abs/2602.10377
-    pdf_url: https://arxiv.org/pdf/2602.10377
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: r0BpntZqJG4C
-  - key: faarformat2026
-    title: "FAAR: Format-Aware Adaptive Rounding for NVFP4"
-    authors: H Li, S Tian, C Lin, Z Zhao, K Zhan
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.22370 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4JMBOYKVnBMC
-    external_url: https://arxiv.org/abs/2603.22370
-    pdf_url: https://arxiv.org/pdf/2603.22370
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 4JMBOYKVnBMC
-  - key: evaluatingthe2026
-    title: Evaluating the Search Agent in a Parallel World
-    authors: J Chen, X Shen, L Zheng, L Mu, H Sun, N Mao, H Ma, T Wei, P Zhou, ...
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.04751 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_Qo2XoVZTnwC
-    external_url: https://arxiv.org/abs/2603.04751
-    pdf_url: https://arxiv.org/pdf/2603.04751
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: _Qo2XoVZTnwC
-  - key: drivelidar4d2025
-    title: "DriveLiDAR4D: Sequential and Controllable LiDAR Scene Generation for Autonomous
-      Driving"
-    authors: K Cai, X Liu, X Zhou, H Hu, J Xiang, L Zhang, X Zhang, K Zhan, Y Zhan,
-      ...
-    year: "2026"
-    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (4), 2525-2533
-      [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ZeXyd9-uunAC
-    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/37239
-    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/37239/41201
-    doi: 10.48550/arXiv.2511.13309
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: ZeXyd9-uunAC
-  - key: drivecombobenchmarking2026
-    title: "DriveCombo: Benchmarking Compositional Traffic Rule Reasoning in Autonomous
-      Driving"
-    authors: E Ma, J Zhang, G Zheng, T Tang, SE Li, Y Lu, X Zhou, X Zhang, Y Zhan, ...
-    year: "2026"
-    venue: arXiv preprint arXiv:2603.01637 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:R3hNpaxXUhUC
-    external_url: https://arxiv.org/abs/2603.01637
-    pdf_url: https://arxiv.org/pdf/2603.01637
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: R3hNpaxXUhUC
-  - key: streetgaussians2025
-    title: "Street Gaussians: Modeling Dynamic Urban Scenes With Gaussian Primitives"
-    authors: S Peng, Y Long, Y Yan, H Lin, C Zhou, H Sun, K Zhan, X Lang, H Bao, ...
-    year: "2025"
-    venue: IEEE transactions on pattern analysis and machine intelligence [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:L8Ckcad2t8MC
-    external_url: https://ieeexplore.ieee.org/abstract/document/11260967/
-    pdf_url: https://drive.google.com/file/d/1NWpnbFzPnxyrFch9aCCbEZxLZn9xCjib/view
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: L8Ckcad2t8MC
-  - key: sparseworldtc2025
-    title: "SparseWorld-TC: Trajectory-Conditioned Sparse Occupancy World Model"
-    authors: J Du, Y Zhao, Z Guo, Y Pan, W Hou, Z Hao, K Zhan, Q Chen
-    year: "2025"
-    venue: arXiv preprint arXiv:2511.22039 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qUcmZB5y_30C
-    external_url: https://arxiv.org/abs/2511.22039
-    pdf_url: https://arxiv.org/pdf/2511.22039
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: qUcmZB5y_30C
-  - key: hineushigh2025
-    title: "HiNeuS: High-fidelity Neural Surface Mitigating Low-texture and Reflective
-      Ambiguity"
-    authors: Y Wang, X Zhang, K Zhan, P Jia, X Lang
-    year: "2025"
-    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-      [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4TOpqqG69KYC
-    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: 4TOpqqG69KYC
-  - key: hierarchyugp2025
-    title: "Hierarchy UGP: Hierarchy Unified Gaussian Primitive for Large-Scale Dynamic
-      Scene Reconstruction"
-    authors: H Sun, Q Yang, J Wang, Z Xu, C Liu, Y Wang, K Zhan, H Bao, X Zhou, ...
-    year: "2025"
-    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-      [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-    citation_count: null
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:QIV2ME_5wuYC
-    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: ""
-    google_scholar_id: QIV2ME_5wuYC
+- key: drivevlm2024
+  title: 'Drivevlm: The convergence of autonomous driving and large vision-language
+    models'
+  authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
+  year: '2024'
+  venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
+  citation_count: 562
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
+  external_url: https://arxiv.org/abs/2402.12289
+  pdf_url: https://arxiv.org/pdf/2402.12289
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/drivevlm2024.png
+  google_scholar_id: zYLM7Y9cAGgC
+- key: street2024
+  title: 'Street gaussians: Modeling dynamic urban scenes with gaussian splatting'
+  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+  year: '2024'
+  venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
+  citation_count: 406
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
+  external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
+  pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/street2024-preview.png
+  google_scholar_id: IjCSPb-OGe4C
+- key: recondreamer2025
+  title: 'Recondreamer: Crafting world models for driving scene reconstruction via
+    online restoration'
+  authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
+    [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
+  citation_count: 86
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: LkGwnXOMwfcC
+- key: planagent2024
+  title: 'Planagent: A multi-modal large language agent for closed-loop vehicle motion
+    planning'
+  authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
+  year: '2026'
+  venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
+  citation_count: 55
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
+  external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
+  pdf_url: https://arxiv.org/pdf/2406.01587
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: Tyk-4Ss8FVUC
+- key: unleashing2024
+  title: Unleashing generalization of end-to-end autonomous driving with controllable
+    long video generation
+  authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
+  citation_count: 51
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
+  external_url: https://arxiv.org/abs/2406.01349
+  pdf_url: https://arxiv.org/pdf/2406.01349
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: W7OEmFMy1HYC
+- key: streetcrafter2025
+  title: 'Streetcrafter: Street view synthesis with controllable video diffusion models'
+  authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
+    ...
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
+    [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
+  citation_count: 43
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: Se3iqnhoufwC
+- key: tod3cap2024
+  title: 'Tod3cap: Towards 3d dense captioning in outdoor scenes'
+  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+    ...
+  year: '2024'
+  venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
+  citation_count: 42
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
+  external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
+  pdf_url: https://arxiv.org/pdf/2403.19589?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: ufrVoPGSRksC
+- key: drivingsphere2025
+  title: 'Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation'
+  authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
+    [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
+  citation_count: 32
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: UebtZRa9Y70C
+- key: finetuning2025
+  title: Finetuning generative trajectory model with reinforcement learning from human
+    feedback
+  authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
+    Xu, ...
+  year: '2025'
+  venue: 'arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741'
+  citation_count: 31
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
+  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/finetuning2025-preview.png
+  google_scholar_id: MXK_kJrjxJIC
+- key: dive2024
+  title: 'Dive: Dit-based video generation with enhanced control'
+  authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
+    ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
+  citation_count: 31
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
+  external_url: https://arxiv.org/abs/2409.01595
+  pdf_url: https://arxiv.org/pdf/2409.01595
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: YsMSGLbcyi4C
+- key: 3drealcar2024
+  title: '3drealcar: An in-the-wild rgb-d car dataset with 360-degree views'
+  authors: X Du, Y Wang, H Sun, Z Wu, H Sheng, S Wang, J Ying, M Lu, T Zhu, ...
+  year: '2025'
+  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+    [26](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905
+  citation_count: 25
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Y0pCki6q_DkC
+  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: Y0pCki6q_DkC
+- key: bevclip2024
+  title: 'Bev-clip: Multi-modal bev retrieval methodology for complex scene in autonomous
+    driving'
+  authors: Z Jia, T Gao, C Cai, C Hou, P Jia, F JingChen, Y ZHAO, K Zhan, FU LIU,
+    ...[24](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17455078764301502962)2024
+  year: '2024'
+  venue: ''
+  citation_count: 24
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:0EnyYjriUFMC
+  external_url: https://openreview.net/forum?id=wlqkRFRkYc
+  pdf_url: https://openreview.net/pdf?id=wlqkRFRkYc
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 0EnyYjriUFMC
+- key: generalizing2024
+  title: Generalizing motion planners with mixture of experts for autonomous driving
+  authors: Q Sun, H Wang, J Zhan, F Nie, X Wen, L Xu, K Zhan, P Jia, X Lang, ...
+  year: '2025'
+  venue: IEEE International Conference on Robotics and Automation (ICRA), 6033-6039
+    [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8525832948576027576
+  citation_count: 23
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_FxGoFyzp5QC
+  external_url: https://ieeexplore.ieee.org/abstract/document/11127274/
+  pdf_url: https://arxiv.org/pdf/2410.15774?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: _FxGoFyzp5QC
+- key: thebetter2025
+  title: 'The better you learn, the smarter you prune: Towards efficient vision-language-action
+    models via differentiable token pruning'
+  authors: T Jiang, X Jiang, Y Ma, X Wen, B Li, K Zhan, P Jia, Y Liu, S Sun, X Lang
+  year: '2025'
+  venue: arXiv preprint arXiv:2509.12594 [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439
+  citation_count: 22
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:aqlVkmm33-oC
+  external_url: https://arxiv.org/abs/2509.12594
+  pdf_url: https://arxiv.org/pdf/2509.12594?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: aqlVkmm33-oC
+- key: transdiffuser2025
+  title: 'Transdiffuser: End-to-end trajectory generation with decorrelated multi-modal
+    representation for autonomous driving'
+  authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, XP Lang, S Sun
+  year: '2025'
+  venue: 'arXiv e-prints, arXiv: 2505.09315 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773'
+  citation_count: 21
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Zph67rFs4hoC
+  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250509315J/abstract
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: Zph67rFs4hoC
+- key: bevtsr2025
+  title: 'Bev-tsr: Text-scene retrieval in bev space for autonomous driving'
+  authors: T Tang, D Wei, Z Jia, T Gao, C Cai, C Hou, P Jia, K Zhan, H Sun, ...
+  year: '2025'
+  venue: Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283
+    [19](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481
+  citation_count: 17
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:eQOLeE2rZwMC
+  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/32782
+  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/32782/34937
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: eQOLeE2rZwMC
+- key: joint2015
+  title: Joint tracking and classification with constraints and reassignment by radar
+    and ESM
+  authors: H Jiang, K Zhan, L Xu
+  year: '2015'
+  venue: Digital Signal Processing 40, 213-223 [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2198228601778586949
+  citation_count: 17
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:2osOgNQ5qMEC
+  external_url: https://www.sciencedirect.com/science/article/pii/S105120041500024X
+  pdf_url: https://www.researchgate.net/profile/Kun-Zhan-4/publication/272522907_Joint_tracking_and_classification_with_constraints_and_reassignment_by_radar_and_ESM/links/5dd4aa18458515cd48ac0bc6/Joint-tracking-and-classification-with-constraints-and-reassignment-by-radar-and-ESM.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 2osOgNQ5qMEC
+- key: geodrive2025
+  title: 'Geodrive: 3d geometry-informed driving world model with precise action control'
+  authors: A Chen, W Zheng, Y Wang, X Zhang, K Zhan, P Jia, K Keutzer, S Zhang
+  year: '2025'
+  venue: arXiv preprint arXiv:2505.22421 [16](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204
+  citation_count: 15
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YOwf2qJgpHMC
+  external_url: https://arxiv.org/abs/2505.22421
+  pdf_url: https://arxiv.org/pdf/2505.22421
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: YOwf2qJgpHMC
+- key: joint2014
+  title: Joint tracking and classification based on aerodynamic model and radar cross
+    section
+  authors: H Jiang, L Xu, K Zhan
+  year: '2014'
+  venue: Pattern recognition 47 (9), 3096-3105 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7434382400669015995
+  citation_count: 15
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qjMakFHDy7sC
+  external_url: https://www.sciencedirect.com/science/article/pii/S0031320314000715
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: qjMakFHDy7sC
+- key: balanced2024
+  title: 'Balanced 3DGS: Gaussian-wise parallelism rendering with fine-grained tiling'
+  authors: H Gui, L Hu, R Chen, M Huang, Y Yin, J Yang, Y Wu, C Liu, Z Sun, ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2412.17378 [13](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687
+  citation_count: 12
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:roLk4NBRz8UC
+  external_url: https://arxiv.org/abs/2412.17378
+  pdf_url: https://arxiv.org/pdf/2412.17378?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: roLk4NBRz8UC
+- key: street2023
+  title: Street gaussians for modeling dynamic urban scenes.(2023)
+  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+  year: '2023'
+  venue: arXiv preprint arXiv:2401.01339 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2617111234141021442
+  citation_count: 11
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:5nxA0vEk-isC
+  external_url: https://scholar.google.com/scholar?cluster=2617111234141021442&hl=en&oi=scholarr
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 5nxA0vEk-isC
+- key: worldrftlatent2026
+  title: 'WorldRFT: Latent world model planning with reinforcement fine-tuning for
+    autonomous driving'
+  authors: P Yang, B Lu, Z Xia, C Han, Y Gao, T Zhang, K Zhan, XP Lang, Y Zheng, ...
+  year: '2026'
+  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649…
+    [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555
+  citation_count: 10
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hC7cP41nSMkC
+  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/38149
+  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/38149/42111
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: hC7cP41nSMkC
+- key: discretediffusion2025
+  title: Discrete diffusion for reflective vision-language-action models in autonomous
+    driving
+  authors: P Li, Y Zheng, Y Wang, H Wang, H Zhao, J Liu, X Zhan, K Zhan, X Lang
+  year: '2025'
+  venue: arXiv preprint arXiv:2509.20109 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583
+  citation_count: 10
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Wp0gIr-vW9MC
+  external_url: https://arxiv.org/abs/2509.20109
+  pdf_url: https://arxiv.org/pdf/2509.20109?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: Wp0gIr-vW9MC
+- key: driveagentr120252
+  title: 'DriveAgent-R1: Advancing VLM-based autonomous driving with hybrid thinking
+    and active perception'
+  authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
+  year: '2025'
+  venue: 'arXiv e-prints, arXiv: 2507.20879 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899'
+  citation_count: 9
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qxL8FJ1GzNcC
+  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250720879Z/abstract
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: qxL8FJ1GzNcC
+- key: uatrack2024
+  title: 'Ua-track: Uncertainty-aware end-to-end 3d multi-object tracking'
+  authors: L Zhou, T Tang, P Hao, Z He, K Ho, S Gu, W Hou, Z Hao, H Sun, K Zhan, ...
+  year: '2024'
+  venue: 'arXiv e-prints, arXiv: 2406.02147 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580'
+  citation_count: 9
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:WF5omc3nYNoC
+  external_url: https://scholar.google.com/scholar?cluster=15720233251267028580&hl=en&oi=scholarr
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: WF5omc3nYNoC
+- key: dive1961
+  title: 'Dive: Efficient multi-view driving scenes generation based on video diffusion
+    transformer'
+  authors: J Jiang, G Hong, M Zhang, H Hu, K Zhan, R Shao, L Nie
+  year: '2025'
+  venue: arXiv preprint arXiv:2504.19614 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17699301463624196526
+  citation_count: 6
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:3fE2CSJIrl8C
+  external_url: https://arxiv.org/abs/2504.19614
+  pdf_url: https://arxiv.org/pdf/2504.19614
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 3fE2CSJIrl8C
+- key: adr12025
+  title: 'AD-R1: Closed-Loop Reinforcement Learning for End-to-End Autonomous Driving
+    with Impartial World Models'
+  authors: T Yan, T Tang, X Gui, Y Li, J Zhesng, W Huang, L Kong, W Han, X Zhou, ...
+  year: '2025'
+  venue: arXiv preprint arXiv:2511.20325 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649
+  citation_count: 6
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IWHjjKOFINEC
+  external_url: https://arxiv.org/abs/2511.20325
+  pdf_url: https://arxiv.org/pdf/2511.20325
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: IWHjjKOFINEC
+- key: xiaoxiaolong2024
+  title: 'Xiaoxiao Long, Yilun Chen, and Hao Zhao. Tod3cap: Towards 3d dense captioning
+    in outdoor scenes'
+  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+    ...
+  year: '2024'
+  venue: Computer Vision–ECCV, 367-384 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7647393139940744594
+  citation_count: 6
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:M3ejUd6NZC8C
+  external_url: https://scholar.google.com/scholar?cluster=7647393139940744594&hl=en&oi=scholarr
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: M3ejUd6NZC8C
+- key: joint20142
+  title: Joint tracking and classification on aerodynamic model and RCS by ground-based
+    passive radar
+  authors: L Xu, K Zhan, H Jiang, L Bai, M Wu
+  year: '2014'
+  venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
+    [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1850746215740028633
+  citation_count: 6
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:9yKSN-GCB0IC
+  external_url: https://ieeexplore.ieee.org/abstract/document/7007306/
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 9yKSN-GCB0IC
+- key: robopearls2025
+  title: 'RoboPearls: editable video simulation for robot manipulation'
+  authors: T Tao, L Zhang, Y Wen, K Zhang, JW Bian, X Zhou, T Yan, K Zhan, P Jia,
+    ...
+  year: '2025'
+  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+    [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2125478236741172501
+  citation_count: 5
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_kc_bZDykSQC
+  external_url: https://doi.org/10.48550/arXiv.2506.22756
+  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Tao_RoboPearls_Editable_Video_Simulation_for_Robot_Manipulation_ICCV_2025_paper.pdf
+  doi: 10.48550/arXiv.2506.22756
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: _kc_bZDykSQC
+- key: s2track2024
+  title: 'S2-track: A simple yet strong approach for end-to-end 3d multi-object tracking'
+  authors: T Tang, L Zhou, P Hao, Z He, K Ho, S Gu, Z Hao, H Sun, K Zhan, P Jia, ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2406.02147 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409
+  citation_count: 5
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ULOm3_A8WrAC
+  external_url: https://arxiv.org/abs/2406.02147
+  pdf_url: https://arxiv.org/pdf/2406.02147
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: ULOm3_A8WrAC
+- key: rlgf2025
+  title: 'Rlgf: Reinforcement learning with geometric feedback for autonomous driving
+    video generation'
+  authors: T Yan, W Han, X Zhang, K Zhan, CZ Xu, J Shen
+  year: '2026'
+  venue: Advances in Neural Information Processing Systems 38, 128659-128684 [8](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917
+  citation_count: 4
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC
+  external_url: https://doi.org/10.48550/arXiv.2509.16500
+  pdf_url: https://arxiv.org/pdf/2509.16500
+  doi: 10.48550/arXiv.2509.16500
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 4DMP91E08xMC
+- key: evolvingfrom2026
+  title: Evolving from Tool User to Creator via Training-Free Experience Reuse in
+    Multimodal Reasoning
+  authors: X Shen, J Chen, L Zheng, H Ma, T Wei, K Zhan
+  year: '2026'
+  venue: arXiv preprint arXiv:2602.01983 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910
+  citation_count: 4
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hFOr9nPyWt4C
+  external_url: https://arxiv.org/abs/2602.01983
+  pdf_url: https://arxiv.org/pdf/2602.01983
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: hFOr9nPyWt4C
+- key: posepilot2025
+  title: 'PosePilot: Steering camera pose for generative world models with self-supervised
+    depth'
+  authors: B Jin, W Li, B Yang, Z Zhu, J Jiang, H Gao, H Sun, K Zhan, H Hu, X Zhang,
+    ...
+  year: '2025'
+  venue: IEEE/RSJ International Conference on Intelligent Robots and Systems… [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10498075774223536829
+  citation_count: 4
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:kNdYIx-mwKoC
+  external_url: https://ieeexplore.ieee.org/abstract/document/11247293/
+  pdf_url: https://arxiv.org/pdf/2505.01729
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: kNdYIx-mwKoC
+- key: transdiffuserdiverse2025
+  title: 'Transdiffuser: Diverse trajectory generation with decorrelated multi-modal
+    representation for end-to-end autonomous driving'
+  authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, X Lang, S Sun
+  year: '2025'
+  venue: arXiv preprint arXiv:2505.09315 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12624178323067622969
+  citation_count: 3
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:HDshCWvjkbEC
+  external_url: https://arxiv.org/abs/2505.09315
+  pdf_url: https://arxiv.org/pdf/2505.09315
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: HDshCWvjkbEC
+- key: omnigen2025
+  title: 'Omnigen: Unified multimodal sensor generation for autonomous driving'
+  authors: T Tang, E Ma, X Zhou, L Wang, T Yan, X Zhang, K Zhan, P Jia, X Lang, ...
+  year: '2025'
+  venue: Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374
+    [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086
+  citation_count: 3
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mVmsd5A6BfQC
+  external_url: https://doi.org/10.48550/arXiv.2512.14225
+  pdf_url: https://dl.acm.org/doi/pdf/10.1145/3746027.3754772
+  doi: 10.48550/arXiv.2512.14225
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: mVmsd5A6BfQC
+- key: learningpersonalized2025
+  title: Learning Personalized Driving Styles via Reinforcement Learning from Human
+    Feedback
+  authors: D Li, C Li, Y Wang, J Ren, X Wen, P Li, L Xu, K Zhan, P Jia, X Lang, N
+    Xu, ...
+  year: '2025'
+  venue: arXiv preprint arXiv:2503.10434 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182
+  citation_count: 3
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mB3voiENLucC
+  external_url: https://arxiv.org/abs/2503.10434
+  pdf_url: https://arxiv.org/pdf/2503.10434
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: mB3voiENLucC
+- key: driveagentr12025
+  title: 'DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception
+    and Hybrid Thinking'
+  authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
+  year: '2025'
+  venue: arXiv preprint arXiv:2507.20879 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237
+  citation_count: 3
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:dhFuZR0502QC
+  external_url: https://arxiv.org/abs/2507.20879
+  pdf_url: https://arxiv.org/pdf/2507.20879
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: dhFuZR0502QC
+- key: particle2014
+  title: Particle filter based joint tracking and classification
+  authors: K Zhan, L Xu, H Jiang, L Bai, M Wu
+  year: '2014'
+  venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
+    [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11948931031763077540
+  citation_count: 3
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UeHWp8X0CEIC
+  external_url: https://ieeexplore.ieee.org/abstract/document/7007307/
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: UeHWp8X0CEIC
+- key: correctada2026
+  title: 'Correctad: A self-correcting agentic system to improve end-to-end planning
+    in autonomous driving'
+  authors: E Ma, L Zhou, T Tang, J Zhang, J Jiang, Z Zhang, D Han, K Zhan, X Zhang,
+    ...
+  year: '2026'
+  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (10), 7755-7763
+    [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9391779730238116875
+  citation_count: 1
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:7PzlFSSx8tAC
+  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718
+  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718/41680
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 7PzlFSSx8tAC
+- key: styledstreets2025
+  title: 'StyledStreets: Multi-style Street Simulator with Spatial and Temporal Consistency'
+  authors: Y Chen, Y Wang, X Zhang, K Zhan, P Jia, Y Zhan, X Lang
+  year: '2025'
+  venue: arXiv preprint arXiv:2503.21104 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=36853680135788572
+  citation_count: 1
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hqOjcs7Dif8C
+  external_url: https://arxiv.org/abs/2503.21104
+  pdf_url: https://arxiv.org/pdf/2503.21104?
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: hqOjcs7Dif8C
+- key: unifyinglanguage2026
+  title: Unifying language-action understanding and generation for autonomous driving
+  authors: X Wang, Q Liu, W Ding, Z Yang, W Li, C Liu, B Li, K Zhan, X Lang, ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.01441 [2](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14545021791743234404
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:e5wmG9Sq2KIC
+  external_url: https://arxiv.org/abs/2603.01441
+  pdf_url: https://arxiv.org/pdf/2603.01441
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: e5wmG9Sq2KIC
+- key: streetforwardperceiving2026
+  title: 'StreetForward: Perceiving Dynamic Street with Feedforward Causal Attention'
+  authors: Z Yu, Z Wang, Y Xie, Y Wang, X Zhang, Y Zhan, K Zhan
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.19552 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:j3f4tGmQtD8C
+  external_url: https://arxiv.org/abs/2603.19552
+  pdf_url: https://arxiv.org/pdf/2603.19552
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: j3f4tGmQtD8C
+- key: streamingclawtechnical2026
+  title: StreamingClaw Technical Report
+  authors: J Chen, Z Chen, C Du, M He, W He, H Li, Q Li, Z Liu, H Ma, X Pan, C Ren,
+    ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.22120 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14090650148033921883
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:RHpTSmoSYBkC
+  external_url: https://arxiv.org/abs/2603.22120
+  pdf_url: https://arxiv.org/pdf/2603.22120
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: RHpTSmoSYBkC
+- key: reflectdrive22026
+  title: 'ReflectDrive-2: Reinforcement-Learning-Aligned Self-Editing for Discrete
+    Diffusion Driving'
+  authors: H Wang, Y Wang, B Cui, P Li, B Lu, M Wang, T Wang, C Tang, T Zhang, ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2605.04647 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
+  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: bEWYMUwI8FkC
+- key: methodand2026
+  title: Method and apparatus for generating trajectory, electronic device, storage
+    medium
+  authors: B Li, K Zhan, P Jia, X Lang, Y Wang, J GU, Y Jiang, Q Jiang, S Zhao, ...
+  year: '2026'
+  venue: US Patent App. 19/037,583 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:-f6ydRqryjwC
+  external_url: https://patents.google.com/patent/US20260008479A1/en
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: -f6ydRqryjwC
+- key: m2asynergizing2026
+  title: 'M2A: Synergizing Mathematical and Agentic Reasoning in Large Language Models'
+  authors: J Wang, X Zhou, Q Xu, K Zhan
+  year: '2026'
+  venue: arXiv preprint arXiv:2605.09879 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
+  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: iH-uZ7U-co4C
+- key: hardwareco2026
+  title: Hardware Co-Design Scaling Laws via Roofline Modelling for On-Device LLMs
+  authors: L Sun, J Jiang, Y Ding, F Li, Y Song, H Zhang, J Ying, L Ren, K Zhan, ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2602.10377 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:r0BpntZqJG4C
+  external_url: https://arxiv.org/abs/2602.10377
+  pdf_url: https://arxiv.org/pdf/2602.10377
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: r0BpntZqJG4C
+- key: faarformat2026
+  title: 'FAAR: Format-Aware Adaptive Rounding for NVFP4'
+  authors: H Li, S Tian, C Lin, Z Zhao, K Zhan
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.22370 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4JMBOYKVnBMC
+  external_url: https://arxiv.org/abs/2603.22370
+  pdf_url: https://arxiv.org/pdf/2603.22370
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 4JMBOYKVnBMC
+- key: evaluatingthe2026
+  title: Evaluating the Search Agent in a Parallel World
+  authors: J Chen, X Shen, L Zheng, L Mu, H Sun, N Mao, H Ma, T Wei, P Zhou, ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.04751 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_Qo2XoVZTnwC
+  external_url: https://arxiv.org/abs/2603.04751
+  pdf_url: https://arxiv.org/pdf/2603.04751
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: _Qo2XoVZTnwC
+- key: drivelidar4d2025
+  title: 'DriveLiDAR4D: Sequential and Controllable LiDAR Scene Generation for Autonomous
+    Driving'
+  authors: K Cai, X Liu, X Zhou, H Hu, J Xiang, L Zhang, X Zhang, K Zhan, Y Zhan,
+    ...
+  year: '2026'
+  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (4), 2525-2533
+    [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ZeXyd9-uunAC
+  external_url: https://doi.org/10.48550/arXiv.2511.13309
+  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/37239/41201
+  doi: 10.48550/arXiv.2511.13309
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: ZeXyd9-uunAC
+- key: drivecombobenchmarking2026
+  title: 'DriveCombo: Benchmarking Compositional Traffic Rule Reasoning in Autonomous
+    Driving'
+  authors: E Ma, J Zhang, G Zheng, T Tang, SE Li, Y Lu, X Zhou, X Zhang, Y Zhan, ...
+  year: '2026'
+  venue: arXiv preprint arXiv:2603.01637 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:R3hNpaxXUhUC
+  external_url: https://arxiv.org/abs/2603.01637
+  pdf_url: https://arxiv.org/pdf/2603.01637
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: R3hNpaxXUhUC
+- key: closedloop2026
+  title: Closed Loop Dynamic Driving Data Mixture for Real-Synthetic Co-Training
+  authors: H Ruan, P Liu, W Ma, Z Li, X Zhang, J Ma, D Xu, K Zhan
+  year: '2026'
+  venue: arXiv preprint arXiv:2605.21372 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
+  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: TFP_iSt0sucC
+- key: streetgaussians2025
+  title: 'Street Gaussians: Modeling Dynamic Urban Scenes With Gaussian Primitives'
+  authors: S Peng, Y Long, Y Yan, H Lin, C Zhou, H Sun, K Zhan, X Lang, H Bao, ...
+  year: '2025'
+  venue: IEEE transactions on pattern analysis and machine intelligence [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:L8Ckcad2t8MC
+  external_url: https://ieeexplore.ieee.org/abstract/document/11260967/
+  pdf_url: https://drive.google.com/file/d/1NWpnbFzPnxyrFch9aCCbEZxLZn9xCjib/view
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: L8Ckcad2t8MC
+- key: sparseworldtc2025
+  title: 'SparseWorld-TC: Trajectory-Conditioned Sparse Occupancy World Model'
+  authors: J Du, Y Zhao, Z Guo, Y Pan, W Hou, Z Hao, K Zhan, Q Chen
+  year: '2025'
+  venue: arXiv preprint arXiv:2511.22039 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qUcmZB5y_30C
+  external_url: https://arxiv.org/abs/2511.22039
+  pdf_url: https://arxiv.org/pdf/2511.22039
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: qUcmZB5y_30C
+- key: hineushigh2025
+  title: 'HiNeuS: High-fidelity Neural Surface Mitigating Low-texture and Reflective
+    Ambiguity'
+  authors: Y Wang, X Zhang, K Zhan, P Jia, X Lang
+  year: '2025'
+  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+    [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4TOpqqG69KYC
+  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: 4TOpqqG69KYC
+- key: hierarchyugp2025
+  title: 'Hierarchy UGP: Hierarchy Unified Gaussian Primitive for Large-Scale Dynamic
+    Scene Reconstruction'
+  authors: H Sun, Q Yang, J Wang, Z Xu, C Liu, Y Wang, K Zhan, H Bao, X Zhou, ...
+  year: '2025'
+  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+    [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16823791912791942975
+  citation_count: null
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:QIV2ME_5wuYC
+  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: ''
+  google_scholar_id: QIV2ME_5wuYC
 top_publications:
-  - key: drivevlm2024
-    title: "Drivevlm: The convergence of autonomous driving and large vision-language
-      models"
-    authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
-    year: "2024"
-    venue: arXiv preprint arXiv:2402.12289 [562](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
-    citation_count: 562
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
-    external_url: https://arxiv.org/abs/2402.12289
-    pdf_url: https://arxiv.org/pdf/2402.12289
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/drivevlm2024.png
-    google_scholar_id: zYLM7Y9cAGgC
-  - key: street2024
-    title: "Street gaussians: Modeling dynamic urban scenes with gaussian splatting"
-    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-    year: "2024"
-    venue: European Conference on Computer Vision, 156-173 [406](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
-    citation_count: 406
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
-    external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
-    pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/street2024-preview.png
-    google_scholar_id: IjCSPb-OGe4C
-  - key: recondreamer2025
-    title: "Recondreamer: Crafting world models for driving scene reconstruction via
-      online restoration"
-    authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
-      [86](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
-    citation_count: 86
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/recondreamer2025-pdf-preview.png
-    google_scholar_id: LkGwnXOMwfcC
-  - key: planagent2024
-    title: "Planagent: A multi-modal large language agent for closed-loop vehicle motion
-      planning"
-    authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
-    year: "2026"
-    venue: IEEE Transactions on Cognitive and Developmental Systems [55](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
-    citation_count: 55
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
-    external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
-    pdf_url: https://arxiv.org/pdf/2406.01587
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/planagent2024-pdf-preview.png
-    google_scholar_id: Tyk-4Ss8FVUC
-  - key: unleashing2024
-    title: Unleashing generalization of end-to-end autonomous driving with controllable
-      long video generation
-    authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2406.01349 [51](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
-    citation_count: 51
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
-    external_url: https://arxiv.org/abs/2406.01349
-    pdf_url: https://arxiv.org/pdf/2406.01349
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/unleashing2024-pdf-preview.png
-    google_scholar_id: W7OEmFMy1HYC
-  - key: streetcrafter2025
-    title: "Streetcrafter: Street view synthesis with controllable video diffusion models"
-    authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
-      ...
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
-      [43](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
-    citation_count: 43
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/streetcrafter2025-pdf-preview.jpeg
-    google_scholar_id: Se3iqnhoufwC
-  - key: tod3cap2024
-    title: "Tod3cap: Towards 3d dense captioning in outdoor scenes"
-    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-      ...
-    year: "2024"
-    venue: European Conference on Computer Vision, 367-384 [42](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
-    citation_count: 42
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
-    external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
-    pdf_url: https://arxiv.org/pdf/2403.19589?
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/tod3cap2024-pdf-preview.jpeg
-    google_scholar_id: ufrVoPGSRksC
-  - key: drivingsphere2025
-    title: "Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation"
-    authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
-    year: "2025"
-    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
-      [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
-    citation_count: 32
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
-    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
-    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/drivingsphere2025-pdf-preview.jpeg
-    google_scholar_id: UebtZRa9Y70C
-  - key: finetuning2025
-    title: Finetuning generative trajectory model with reinforcement learning from human
-      feedback
-    authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
-      Xu, ...
-    year: "2025"
-    venue: "arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741"
-    citation_count: 31
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
-    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
-    pdf_url: ""
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/finetuning2025-preview.png
-    google_scholar_id: MXK_kJrjxJIC
-  - key: dive2024
-    title: "Dive: Dit-based video generation with enhanced control"
-    authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
-      ...
-    year: "2024"
-    venue: arXiv preprint arXiv:2409.01595 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
-    citation_count: 31
-    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
-    external_url: https://arxiv.org/abs/2409.01595
-    pdf_url: https://arxiv.org/pdf/2409.01595
-    doi: ""
-    arxiv: ""
-    preview_image: /assets/img/publication_preview/dive2024-pdf-preview.jpeg
-    google_scholar_id: YsMSGLbcyi4C
+- key: drivevlm2024
+  title: 'Drivevlm: The convergence of autonomous driving and large vision-language
+    models'
+  authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
+  year: '2024'
+  venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
+  citation_count: 562
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
+  external_url: https://arxiv.org/abs/2402.12289
+  pdf_url: https://arxiv.org/pdf/2402.12289
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/drivevlm2024.png
+  google_scholar_id: zYLM7Y9cAGgC
+- key: street2024
+  title: 'Street gaussians: Modeling dynamic urban scenes with gaussian splatting'
+  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+  year: '2024'
+  venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
+  citation_count: 406
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
+  external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
+  pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/street2024-preview.png
+  google_scholar_id: IjCSPb-OGe4C
+- key: recondreamer2025
+  title: 'Recondreamer: Crafting world models for driving scene reconstruction via
+    online restoration'
+  authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
+    [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
+  citation_count: 86
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/recondreamer2025-pdf-preview.png
+  google_scholar_id: LkGwnXOMwfcC
+- key: planagent2024
+  title: 'Planagent: A multi-modal large language agent for closed-loop vehicle motion
+    planning'
+  authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
+  year: '2026'
+  venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
+  citation_count: 55
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
+  external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
+  pdf_url: https://arxiv.org/pdf/2406.01587
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/planagent2024-pdf-preview.png
+  google_scholar_id: Tyk-4Ss8FVUC
+- key: unleashing2024
+  title: Unleashing generalization of end-to-end autonomous driving with controllable
+    long video generation
+  authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
+  citation_count: 51
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
+  external_url: https://arxiv.org/abs/2406.01349
+  pdf_url: https://arxiv.org/pdf/2406.01349
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/unleashing2024-pdf-preview.png
+  google_scholar_id: W7OEmFMy1HYC
+- key: streetcrafter2025
+  title: 'Streetcrafter: Street view synthesis with controllable video diffusion models'
+  authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
+    ...
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
+    [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
+  citation_count: 43
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/streetcrafter2025-pdf-preview.jpeg
+  google_scholar_id: Se3iqnhoufwC
+- key: tod3cap2024
+  title: 'Tod3cap: Towards 3d dense captioning in outdoor scenes'
+  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+    ...
+  year: '2024'
+  venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
+  citation_count: 42
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
+  external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
+  pdf_url: https://arxiv.org/pdf/2403.19589?
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/tod3cap2024-pdf-preview.jpeg
+  google_scholar_id: ufrVoPGSRksC
+- key: drivingsphere2025
+  title: 'Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation'
+  authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
+  year: '2025'
+  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
+    [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
+  citation_count: 32
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
+  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
+  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/drivingsphere2025-pdf-preview.jpeg
+  google_scholar_id: UebtZRa9Y70C
+- key: finetuning2025
+  title: Finetuning generative trajectory model with reinforcement learning from human
+    feedback
+  authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
+    Xu, ...
+  year: '2025'
+  venue: 'arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741'
+  citation_count: 31
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
+  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
+  pdf_url: ''
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/finetuning2025-preview.png
+  google_scholar_id: MXK_kJrjxJIC
+- key: dive2024
+  title: 'Dive: Dit-based video generation with enhanced control'
+  authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
+    ...
+  year: '2024'
+  venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
+  citation_count: 31
+  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
+  external_url: https://arxiv.org/abs/2409.01595
+  pdf_url: https://arxiv.org/pdf/2409.01595
+  doi: ''
+  arxiv: ''
+  preview_image: /assets/img/publication_preview/dive2024-pdf-preview.jpeg
+  google_scholar_id: YsMSGLbcyi4C

--- a/_data/scholar.yml
+++ b/_data/scholar.yml
@@ -3,946 +3,946 @@ profile:
   citations: 1335
   h_index: 15
   i10_index: 21
-  updated_at: '2026-05-27T12:24:48Z'
+  updated_at: "2026-05-27T12:24:48Z"
 publications:
-- key: drivevlm2024
-  title: 'Drivevlm: The convergence of autonomous driving and large vision-language
-    models'
-  authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
-  year: '2024'
-  venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
-  citation_count: 562
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
-  external_url: https://arxiv.org/abs/2402.12289
-  pdf_url: https://arxiv.org/pdf/2402.12289
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/drivevlm2024.png
-  google_scholar_id: zYLM7Y9cAGgC
-- key: street2024
-  title: 'Street gaussians: Modeling dynamic urban scenes with gaussian splatting'
-  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-  year: '2024'
-  venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
-  citation_count: 406
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
-  external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
-  pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/street2024-preview.png
-  google_scholar_id: IjCSPb-OGe4C
-- key: recondreamer2025
-  title: 'Recondreamer: Crafting world models for driving scene reconstruction via
-    online restoration'
-  authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
-    [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
-  citation_count: 86
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: LkGwnXOMwfcC
-- key: planagent2024
-  title: 'Planagent: A multi-modal large language agent for closed-loop vehicle motion
-    planning'
-  authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
-  year: '2026'
-  venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
-  citation_count: 55
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
-  external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
-  pdf_url: https://arxiv.org/pdf/2406.01587
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: Tyk-4Ss8FVUC
-- key: unleashing2024
-  title: Unleashing generalization of end-to-end autonomous driving with controllable
-    long video generation
-  authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
-  citation_count: 51
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
-  external_url: https://arxiv.org/abs/2406.01349
-  pdf_url: https://arxiv.org/pdf/2406.01349
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: W7OEmFMy1HYC
-- key: streetcrafter2025
-  title: 'Streetcrafter: Street view synthesis with controllable video diffusion models'
-  authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
-    ...
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
-    [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
-  citation_count: 43
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: Se3iqnhoufwC
-- key: tod3cap2024
-  title: 'Tod3cap: Towards 3d dense captioning in outdoor scenes'
-  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-    ...
-  year: '2024'
-  venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
-  citation_count: 42
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
-  external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
-  pdf_url: https://arxiv.org/pdf/2403.19589?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: ufrVoPGSRksC
-- key: drivingsphere2025
-  title: 'Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation'
-  authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
-    [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
-  citation_count: 32
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: UebtZRa9Y70C
-- key: finetuning2025
-  title: Finetuning generative trajectory model with reinforcement learning from human
-    feedback
-  authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
-    Xu, ...
-  year: '2025'
-  venue: 'arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741'
-  citation_count: 31
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
-  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/finetuning2025-preview.png
-  google_scholar_id: MXK_kJrjxJIC
-- key: dive2024
-  title: 'Dive: Dit-based video generation with enhanced control'
-  authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
-    ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
-  citation_count: 31
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
-  external_url: https://arxiv.org/abs/2409.01595
-  pdf_url: https://arxiv.org/pdf/2409.01595
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: YsMSGLbcyi4C
-- key: 3drealcar2024
-  title: '3drealcar: An in-the-wild rgb-d car dataset with 360-degree views'
-  authors: X Du, Y Wang, H Sun, Z Wu, H Sheng, S Wang, J Ying, M Lu, T Zhu, ...
-  year: '2025'
-  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-    [26](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905
-  citation_count: 25
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Y0pCki6q_DkC
-  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: Y0pCki6q_DkC
-- key: bevclip2024
-  title: 'Bev-clip: Multi-modal bev retrieval methodology for complex scene in autonomous
-    driving'
-  authors: Z Jia, T Gao, C Cai, C Hou, P Jia, F JingChen, Y ZHAO, K Zhan, FU LIU,
-    ...[24](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17455078764301502962)2024
-  year: '2024'
-  venue: ''
-  citation_count: 24
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:0EnyYjriUFMC
-  external_url: https://openreview.net/forum?id=wlqkRFRkYc
-  pdf_url: https://openreview.net/pdf?id=wlqkRFRkYc
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 0EnyYjriUFMC
-- key: generalizing2024
-  title: Generalizing motion planners with mixture of experts for autonomous driving
-  authors: Q Sun, H Wang, J Zhan, F Nie, X Wen, L Xu, K Zhan, P Jia, X Lang, ...
-  year: '2025'
-  venue: IEEE International Conference on Robotics and Automation (ICRA), 6033-6039
-    [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8525832948576027576
-  citation_count: 23
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_FxGoFyzp5QC
-  external_url: https://ieeexplore.ieee.org/abstract/document/11127274/
-  pdf_url: https://arxiv.org/pdf/2410.15774?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: _FxGoFyzp5QC
-- key: thebetter2025
-  title: 'The better you learn, the smarter you prune: Towards efficient vision-language-action
-    models via differentiable token pruning'
-  authors: T Jiang, X Jiang, Y Ma, X Wen, B Li, K Zhan, P Jia, Y Liu, S Sun, X Lang
-  year: '2025'
-  venue: arXiv preprint arXiv:2509.12594 [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439
-  citation_count: 22
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:aqlVkmm33-oC
-  external_url: https://arxiv.org/abs/2509.12594
-  pdf_url: https://arxiv.org/pdf/2509.12594?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: aqlVkmm33-oC
-- key: transdiffuser2025
-  title: 'Transdiffuser: End-to-end trajectory generation with decorrelated multi-modal
-    representation for autonomous driving'
-  authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, XP Lang, S Sun
-  year: '2025'
-  venue: 'arXiv e-prints, arXiv: 2505.09315 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773'
-  citation_count: 21
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Zph67rFs4hoC
-  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250509315J/abstract
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: Zph67rFs4hoC
-- key: bevtsr2025
-  title: 'Bev-tsr: Text-scene retrieval in bev space for autonomous driving'
-  authors: T Tang, D Wei, Z Jia, T Gao, C Cai, C Hou, P Jia, K Zhan, H Sun, ...
-  year: '2025'
-  venue: Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283
-    [19](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481
-  citation_count: 17
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:eQOLeE2rZwMC
-  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/32782
-  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/32782/34937
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: eQOLeE2rZwMC
-- key: joint2015
-  title: Joint tracking and classification with constraints and reassignment by radar
-    and ESM
-  authors: H Jiang, K Zhan, L Xu
-  year: '2015'
-  venue: Digital Signal Processing 40, 213-223 [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2198228601778586949
-  citation_count: 17
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:2osOgNQ5qMEC
-  external_url: https://www.sciencedirect.com/science/article/pii/S105120041500024X
-  pdf_url: https://www.researchgate.net/profile/Kun-Zhan-4/publication/272522907_Joint_tracking_and_classification_with_constraints_and_reassignment_by_radar_and_ESM/links/5dd4aa18458515cd48ac0bc6/Joint-tracking-and-classification-with-constraints-and-reassignment-by-radar-and-ESM.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 2osOgNQ5qMEC
-- key: geodrive2025
-  title: 'Geodrive: 3d geometry-informed driving world model with precise action control'
-  authors: A Chen, W Zheng, Y Wang, X Zhang, K Zhan, P Jia, K Keutzer, S Zhang
-  year: '2025'
-  venue: arXiv preprint arXiv:2505.22421 [16](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204
-  citation_count: 15
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YOwf2qJgpHMC
-  external_url: https://arxiv.org/abs/2505.22421
-  pdf_url: https://arxiv.org/pdf/2505.22421
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: YOwf2qJgpHMC
-- key: joint2014
-  title: Joint tracking and classification based on aerodynamic model and radar cross
-    section
-  authors: H Jiang, L Xu, K Zhan
-  year: '2014'
-  venue: Pattern recognition 47 (9), 3096-3105 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7434382400669015995
-  citation_count: 15
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qjMakFHDy7sC
-  external_url: https://www.sciencedirect.com/science/article/pii/S0031320314000715
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: qjMakFHDy7sC
-- key: balanced2024
-  title: 'Balanced 3DGS: Gaussian-wise parallelism rendering with fine-grained tiling'
-  authors: H Gui, L Hu, R Chen, M Huang, Y Yin, J Yang, Y Wu, C Liu, Z Sun, ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2412.17378 [13](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687
-  citation_count: 12
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:roLk4NBRz8UC
-  external_url: https://arxiv.org/abs/2412.17378
-  pdf_url: https://arxiv.org/pdf/2412.17378?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: roLk4NBRz8UC
-- key: street2023
-  title: Street gaussians for modeling dynamic urban scenes.(2023)
-  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-  year: '2023'
-  venue: arXiv preprint arXiv:2401.01339 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2617111234141021442
-  citation_count: 11
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:5nxA0vEk-isC
-  external_url: https://scholar.google.com/scholar?cluster=2617111234141021442&hl=en&oi=scholarr
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 5nxA0vEk-isC
-- key: worldrftlatent2026
-  title: 'WorldRFT: Latent world model planning with reinforcement fine-tuning for
-    autonomous driving'
-  authors: P Yang, B Lu, Z Xia, C Han, Y Gao, T Zhang, K Zhan, XP Lang, Y Zheng, ...
-  year: '2026'
-  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649…
-    [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555
-  citation_count: 10
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hC7cP41nSMkC
-  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/38149
-  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/38149/42111
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: hC7cP41nSMkC
-- key: discretediffusion2025
-  title: Discrete diffusion for reflective vision-language-action models in autonomous
-    driving
-  authors: P Li, Y Zheng, Y Wang, H Wang, H Zhao, J Liu, X Zhan, K Zhan, X Lang
-  year: '2025'
-  venue: arXiv preprint arXiv:2509.20109 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583
-  citation_count: 10
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Wp0gIr-vW9MC
-  external_url: https://arxiv.org/abs/2509.20109
-  pdf_url: https://arxiv.org/pdf/2509.20109?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: Wp0gIr-vW9MC
-- key: driveagentr120252
-  title: 'DriveAgent-R1: Advancing VLM-based autonomous driving with hybrid thinking
-    and active perception'
-  authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
-  year: '2025'
-  venue: 'arXiv e-prints, arXiv: 2507.20879 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899'
-  citation_count: 9
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qxL8FJ1GzNcC
-  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250720879Z/abstract
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: qxL8FJ1GzNcC
-- key: uatrack2024
-  title: 'Ua-track: Uncertainty-aware end-to-end 3d multi-object tracking'
-  authors: L Zhou, T Tang, P Hao, Z He, K Ho, S Gu, W Hou, Z Hao, H Sun, K Zhan, ...
-  year: '2024'
-  venue: 'arXiv e-prints, arXiv: 2406.02147 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580'
-  citation_count: 9
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:WF5omc3nYNoC
-  external_url: https://scholar.google.com/scholar?cluster=15720233251267028580&hl=en&oi=scholarr
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: WF5omc3nYNoC
-- key: dive1961
-  title: 'Dive: Efficient multi-view driving scenes generation based on video diffusion
-    transformer'
-  authors: J Jiang, G Hong, M Zhang, H Hu, K Zhan, R Shao, L Nie
-  year: '2025'
-  venue: arXiv preprint arXiv:2504.19614 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17699301463624196526
-  citation_count: 6
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:3fE2CSJIrl8C
-  external_url: https://arxiv.org/abs/2504.19614
-  pdf_url: https://arxiv.org/pdf/2504.19614
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 3fE2CSJIrl8C
-- key: adr12025
-  title: 'AD-R1: Closed-Loop Reinforcement Learning for End-to-End Autonomous Driving
-    with Impartial World Models'
-  authors: T Yan, T Tang, X Gui, Y Li, J Zhesng, W Huang, L Kong, W Han, X Zhou, ...
-  year: '2025'
-  venue: arXiv preprint arXiv:2511.20325 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649
-  citation_count: 6
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IWHjjKOFINEC
-  external_url: https://arxiv.org/abs/2511.20325
-  pdf_url: https://arxiv.org/pdf/2511.20325
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: IWHjjKOFINEC
-- key: xiaoxiaolong2024
-  title: 'Xiaoxiao Long, Yilun Chen, and Hao Zhao. Tod3cap: Towards 3d dense captioning
-    in outdoor scenes'
-  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-    ...
-  year: '2024'
-  venue: Computer Vision–ECCV, 367-384 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7647393139940744594
-  citation_count: 6
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:M3ejUd6NZC8C
-  external_url: https://scholar.google.com/scholar?cluster=7647393139940744594&hl=en&oi=scholarr
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: M3ejUd6NZC8C
-- key: joint20142
-  title: Joint tracking and classification on aerodynamic model and RCS by ground-based
-    passive radar
-  authors: L Xu, K Zhan, H Jiang, L Bai, M Wu
-  year: '2014'
-  venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
-    [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1850746215740028633
-  citation_count: 6
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:9yKSN-GCB0IC
-  external_url: https://ieeexplore.ieee.org/abstract/document/7007306/
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 9yKSN-GCB0IC
-- key: robopearls2025
-  title: 'RoboPearls: editable video simulation for robot manipulation'
-  authors: T Tao, L Zhang, Y Wen, K Zhang, JW Bian, X Zhou, T Yan, K Zhan, P Jia,
-    ...
-  year: '2025'
-  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-    [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2125478236741172501
-  citation_count: 5
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_kc_bZDykSQC
-  external_url: https://doi.org/10.48550/arXiv.2506.22756
-  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Tao_RoboPearls_Editable_Video_Simulation_for_Robot_Manipulation_ICCV_2025_paper.pdf
-  doi: 10.48550/arXiv.2506.22756
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: _kc_bZDykSQC
-- key: s2track2024
-  title: 'S2-track: A simple yet strong approach for end-to-end 3d multi-object tracking'
-  authors: T Tang, L Zhou, P Hao, Z He, K Ho, S Gu, Z Hao, H Sun, K Zhan, P Jia, ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2406.02147 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409
-  citation_count: 5
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ULOm3_A8WrAC
-  external_url: https://arxiv.org/abs/2406.02147
-  pdf_url: https://arxiv.org/pdf/2406.02147
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: ULOm3_A8WrAC
-- key: rlgf2025
-  title: 'Rlgf: Reinforcement learning with geometric feedback for autonomous driving
-    video generation'
-  authors: T Yan, W Han, X Zhang, K Zhan, CZ Xu, J Shen
-  year: '2026'
-  venue: Advances in Neural Information Processing Systems 38, 128659-128684 [8](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917
-  citation_count: 4
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC
-  external_url: https://doi.org/10.48550/arXiv.2509.16500
-  pdf_url: https://arxiv.org/pdf/2509.16500
-  doi: 10.48550/arXiv.2509.16500
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 4DMP91E08xMC
-- key: evolvingfrom2026
-  title: Evolving from Tool User to Creator via Training-Free Experience Reuse in
-    Multimodal Reasoning
-  authors: X Shen, J Chen, L Zheng, H Ma, T Wei, K Zhan
-  year: '2026'
-  venue: arXiv preprint arXiv:2602.01983 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910
-  citation_count: 4
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hFOr9nPyWt4C
-  external_url: https://arxiv.org/abs/2602.01983
-  pdf_url: https://arxiv.org/pdf/2602.01983
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: hFOr9nPyWt4C
-- key: posepilot2025
-  title: 'PosePilot: Steering camera pose for generative world models with self-supervised
-    depth'
-  authors: B Jin, W Li, B Yang, Z Zhu, J Jiang, H Gao, H Sun, K Zhan, H Hu, X Zhang,
-    ...
-  year: '2025'
-  venue: IEEE/RSJ International Conference on Intelligent Robots and Systems… [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10498075774223536829
-  citation_count: 4
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:kNdYIx-mwKoC
-  external_url: https://ieeexplore.ieee.org/abstract/document/11247293/
-  pdf_url: https://arxiv.org/pdf/2505.01729
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: kNdYIx-mwKoC
-- key: transdiffuserdiverse2025
-  title: 'Transdiffuser: Diverse trajectory generation with decorrelated multi-modal
-    representation for end-to-end autonomous driving'
-  authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, X Lang, S Sun
-  year: '2025'
-  venue: arXiv preprint arXiv:2505.09315 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12624178323067622969
-  citation_count: 3
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:HDshCWvjkbEC
-  external_url: https://arxiv.org/abs/2505.09315
-  pdf_url: https://arxiv.org/pdf/2505.09315
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: HDshCWvjkbEC
-- key: omnigen2025
-  title: 'Omnigen: Unified multimodal sensor generation for autonomous driving'
-  authors: T Tang, E Ma, X Zhou, L Wang, T Yan, X Zhang, K Zhan, P Jia, X Lang, ...
-  year: '2025'
-  venue: Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374
-    [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086
-  citation_count: 3
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mVmsd5A6BfQC
-  external_url: https://doi.org/10.48550/arXiv.2512.14225
-  pdf_url: https://dl.acm.org/doi/pdf/10.1145/3746027.3754772
-  doi: 10.48550/arXiv.2512.14225
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: mVmsd5A6BfQC
-- key: learningpersonalized2025
-  title: Learning Personalized Driving Styles via Reinforcement Learning from Human
-    Feedback
-  authors: D Li, C Li, Y Wang, J Ren, X Wen, P Li, L Xu, K Zhan, P Jia, X Lang, N
-    Xu, ...
-  year: '2025'
-  venue: arXiv preprint arXiv:2503.10434 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182
-  citation_count: 3
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mB3voiENLucC
-  external_url: https://arxiv.org/abs/2503.10434
-  pdf_url: https://arxiv.org/pdf/2503.10434
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: mB3voiENLucC
-- key: driveagentr12025
-  title: 'DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception
-    and Hybrid Thinking'
-  authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
-  year: '2025'
-  venue: arXiv preprint arXiv:2507.20879 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237
-  citation_count: 3
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:dhFuZR0502QC
-  external_url: https://arxiv.org/abs/2507.20879
-  pdf_url: https://arxiv.org/pdf/2507.20879
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: dhFuZR0502QC
-- key: particle2014
-  title: Particle filter based joint tracking and classification
-  authors: K Zhan, L Xu, H Jiang, L Bai, M Wu
-  year: '2014'
-  venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
-    [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11948931031763077540
-  citation_count: 3
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UeHWp8X0CEIC
-  external_url: https://ieeexplore.ieee.org/abstract/document/7007307/
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: UeHWp8X0CEIC
-- key: correctada2026
-  title: 'Correctad: A self-correcting agentic system to improve end-to-end planning
-    in autonomous driving'
-  authors: E Ma, L Zhou, T Tang, J Zhang, J Jiang, Z Zhang, D Han, K Zhan, X Zhang,
-    ...
-  year: '2026'
-  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (10), 7755-7763
-    [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9391779730238116875
-  citation_count: 1
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:7PzlFSSx8tAC
-  external_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718
-  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718/41680
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 7PzlFSSx8tAC
-- key: styledstreets2025
-  title: 'StyledStreets: Multi-style Street Simulator with Spatial and Temporal Consistency'
-  authors: Y Chen, Y Wang, X Zhang, K Zhan, P Jia, Y Zhan, X Lang
-  year: '2025'
-  venue: arXiv preprint arXiv:2503.21104 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=36853680135788572
-  citation_count: 1
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hqOjcs7Dif8C
-  external_url: https://arxiv.org/abs/2503.21104
-  pdf_url: https://arxiv.org/pdf/2503.21104?
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: hqOjcs7Dif8C
-- key: unifyinglanguage2026
-  title: Unifying language-action understanding and generation for autonomous driving
-  authors: X Wang, Q Liu, W Ding, Z Yang, W Li, C Liu, B Li, K Zhan, X Lang, ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.01441 [2](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14545021791743234404
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:e5wmG9Sq2KIC
-  external_url: https://arxiv.org/abs/2603.01441
-  pdf_url: https://arxiv.org/pdf/2603.01441
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: e5wmG9Sq2KIC
-- key: streetforwardperceiving2026
-  title: 'StreetForward: Perceiving Dynamic Street with Feedforward Causal Attention'
-  authors: Z Yu, Z Wang, Y Xie, Y Wang, X Zhang, Y Zhan, K Zhan
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.19552 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:j3f4tGmQtD8C
-  external_url: https://arxiv.org/abs/2603.19552
-  pdf_url: https://arxiv.org/pdf/2603.19552
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: j3f4tGmQtD8C
-- key: streamingclawtechnical2026
-  title: StreamingClaw Technical Report
-  authors: J Chen, Z Chen, C Du, M He, W He, H Li, Q Li, Z Liu, H Ma, X Pan, C Ren,
-    ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.22120 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14090650148033921883
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:RHpTSmoSYBkC
-  external_url: https://arxiv.org/abs/2603.22120
-  pdf_url: https://arxiv.org/pdf/2603.22120
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: RHpTSmoSYBkC
-- key: reflectdrive22026
-  title: 'ReflectDrive-2: Reinforcement-Learning-Aligned Self-Editing for Discrete
-    Diffusion Driving'
-  authors: H Wang, Y Wang, B Cui, P Li, B Lu, M Wang, T Wang, C Tang, T Zhang, ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2605.04647 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
-  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: bEWYMUwI8FkC
-- key: methodand2026
-  title: Method and apparatus for generating trajectory, electronic device, storage
-    medium
-  authors: B Li, K Zhan, P Jia, X Lang, Y Wang, J GU, Y Jiang, Q Jiang, S Zhao, ...
-  year: '2026'
-  venue: US Patent App. 19/037,583 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:-f6ydRqryjwC
-  external_url: https://patents.google.com/patent/US20260008479A1/en
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: -f6ydRqryjwC
-- key: m2asynergizing2026
-  title: 'M2A: Synergizing Mathematical and Agentic Reasoning in Large Language Models'
-  authors: J Wang, X Zhou, Q Xu, K Zhan
-  year: '2026'
-  venue: arXiv preprint arXiv:2605.09879 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
-  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: iH-uZ7U-co4C
-- key: hardwareco2026
-  title: Hardware Co-Design Scaling Laws via Roofline Modelling for On-Device LLMs
-  authors: L Sun, J Jiang, Y Ding, F Li, Y Song, H Zhang, J Ying, L Ren, K Zhan, ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2602.10377 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:r0BpntZqJG4C
-  external_url: https://arxiv.org/abs/2602.10377
-  pdf_url: https://arxiv.org/pdf/2602.10377
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: r0BpntZqJG4C
-- key: faarformat2026
-  title: 'FAAR: Format-Aware Adaptive Rounding for NVFP4'
-  authors: H Li, S Tian, C Lin, Z Zhao, K Zhan
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.22370 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4JMBOYKVnBMC
-  external_url: https://arxiv.org/abs/2603.22370
-  pdf_url: https://arxiv.org/pdf/2603.22370
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 4JMBOYKVnBMC
-- key: evaluatingthe2026
-  title: Evaluating the Search Agent in a Parallel World
-  authors: J Chen, X Shen, L Zheng, L Mu, H Sun, N Mao, H Ma, T Wei, P Zhou, ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.04751 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_Qo2XoVZTnwC
-  external_url: https://arxiv.org/abs/2603.04751
-  pdf_url: https://arxiv.org/pdf/2603.04751
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: _Qo2XoVZTnwC
-- key: drivelidar4d2025
-  title: 'DriveLiDAR4D: Sequential and Controllable LiDAR Scene Generation for Autonomous
-    Driving'
-  authors: K Cai, X Liu, X Zhou, H Hu, J Xiang, L Zhang, X Zhang, K Zhan, Y Zhan,
-    ...
-  year: '2026'
-  venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (4), 2525-2533
-    [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ZeXyd9-uunAC
-  external_url: https://doi.org/10.48550/arXiv.2511.13309
-  pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/37239/41201
-  doi: 10.48550/arXiv.2511.13309
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: ZeXyd9-uunAC
-- key: drivecombobenchmarking2026
-  title: 'DriveCombo: Benchmarking Compositional Traffic Rule Reasoning in Autonomous
-    Driving'
-  authors: E Ma, J Zhang, G Zheng, T Tang, SE Li, Y Lu, X Zhou, X Zhang, Y Zhan, ...
-  year: '2026'
-  venue: arXiv preprint arXiv:2603.01637 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:R3hNpaxXUhUC
-  external_url: https://arxiv.org/abs/2603.01637
-  pdf_url: https://arxiv.org/pdf/2603.01637
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: R3hNpaxXUhUC
-- key: closedloop2026
-  title: Closed Loop Dynamic Driving Data Mixture for Real-Synthetic Co-Training
-  authors: H Ruan, P Liu, W Ma, Z Li, X Zhang, J Ma, D Xu, K Zhan
-  year: '2026'
-  venue: arXiv preprint arXiv:2605.21372 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
-  external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: TFP_iSt0sucC
-- key: streetgaussians2025
-  title: 'Street Gaussians: Modeling Dynamic Urban Scenes With Gaussian Primitives'
-  authors: S Peng, Y Long, Y Yan, H Lin, C Zhou, H Sun, K Zhan, X Lang, H Bao, ...
-  year: '2025'
-  venue: IEEE transactions on pattern analysis and machine intelligence [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:L8Ckcad2t8MC
-  external_url: https://ieeexplore.ieee.org/abstract/document/11260967/
-  pdf_url: https://drive.google.com/file/d/1NWpnbFzPnxyrFch9aCCbEZxLZn9xCjib/view
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: L8Ckcad2t8MC
-- key: sparseworldtc2025
-  title: 'SparseWorld-TC: Trajectory-Conditioned Sparse Occupancy World Model'
-  authors: J Du, Y Zhao, Z Guo, Y Pan, W Hou, Z Hao, K Zhan, Q Chen
-  year: '2025'
-  venue: arXiv preprint arXiv:2511.22039 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qUcmZB5y_30C
-  external_url: https://arxiv.org/abs/2511.22039
-  pdf_url: https://arxiv.org/pdf/2511.22039
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: qUcmZB5y_30C
-- key: hineushigh2025
-  title: 'HiNeuS: High-fidelity Neural Surface Mitigating Low-texture and Reflective
-    Ambiguity'
-  authors: Y Wang, X Zhang, K Zhan, P Jia, X Lang
-  year: '2025'
-  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-    [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4TOpqqG69KYC
-  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: 4TOpqqG69KYC
-- key: hierarchyugp2025
-  title: 'Hierarchy UGP: Hierarchy Unified Gaussian Primitive for Large-Scale Dynamic
-    Scene Reconstruction'
-  authors: H Sun, Q Yang, J Wang, Z Xu, C Liu, Y Wang, K Zhan, H Bao, X Zhou, ...
-  year: '2025'
-  venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
-    [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16823791912791942975
-  citation_count: null
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:QIV2ME_5wuYC
-  external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: ''
-  google_scholar_id: QIV2ME_5wuYC
+  - key: drivevlm2024
+    title: "Drivevlm: The convergence of autonomous driving and large vision-language
+      models"
+    authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
+    year: "2024"
+    venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
+    citation_count: 562
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
+    external_url: https://arxiv.org/abs/2402.12289
+    pdf_url: https://arxiv.org/pdf/2402.12289
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/drivevlm2024.png
+    google_scholar_id: zYLM7Y9cAGgC
+  - key: street2024
+    title: "Street gaussians: Modeling dynamic urban scenes with gaussian splatting"
+    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+    year: "2024"
+    venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
+    citation_count: 406
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
+    external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
+    pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/street2024-preview.png
+    google_scholar_id: IjCSPb-OGe4C
+  - key: recondreamer2025
+    title: "Recondreamer: Crafting world models for driving scene reconstruction via
+      online restoration"
+    authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
+      [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
+    citation_count: 86
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: LkGwnXOMwfcC
+  - key: planagent2024
+    title: "Planagent: A multi-modal large language agent for closed-loop vehicle motion
+      planning"
+    authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
+    year: "2026"
+    venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
+    citation_count: 55
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
+    external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
+    pdf_url: https://arxiv.org/pdf/2406.01587
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: Tyk-4Ss8FVUC
+  - key: unleashing2024
+    title: Unleashing generalization of end-to-end autonomous driving with controllable
+      long video generation
+    authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
+    citation_count: 51
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
+    external_url: https://arxiv.org/abs/2406.01349
+    pdf_url: https://arxiv.org/pdf/2406.01349
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: W7OEmFMy1HYC
+  - key: streetcrafter2025
+    title: "Streetcrafter: Street view synthesis with controllable video diffusion models"
+    authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
+      ...
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
+      [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
+    citation_count: 43
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: Se3iqnhoufwC
+  - key: tod3cap2024
+    title: "Tod3cap: Towards 3d dense captioning in outdoor scenes"
+    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+      ...
+    year: "2024"
+    venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
+    citation_count: 42
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
+    external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
+    pdf_url: https://arxiv.org/pdf/2403.19589?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: ufrVoPGSRksC
+  - key: drivingsphere2025
+    title: "Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation"
+    authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
+      [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
+    citation_count: 32
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: UebtZRa9Y70C
+  - key: finetuning2025
+    title: Finetuning generative trajectory model with reinforcement learning from human
+      feedback
+    authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
+      Xu, ...
+    year: "2025"
+    venue: "arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741"
+    citation_count: 31
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
+    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/finetuning2025-preview.png
+    google_scholar_id: MXK_kJrjxJIC
+  - key: dive2024
+    title: "Dive: Dit-based video generation with enhanced control"
+    authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
+      ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
+    citation_count: 31
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
+    external_url: https://arxiv.org/abs/2409.01595
+    pdf_url: https://arxiv.org/pdf/2409.01595
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: YsMSGLbcyi4C
+  - key: 3drealcar2024
+    title: "3drealcar: An in-the-wild rgb-d car dataset with 360-degree views"
+    authors: X Du, Y Wang, H Sun, Z Wu, H Sheng, S Wang, J Ying, M Lu, T Zhu, ...
+    year: "2025"
+    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+      [26](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16116469628850179905
+    citation_count: 25
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Y0pCki6q_DkC
+    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Du_3DRealCar_An_In-the-wild_RGB-D_Car_Dataset_with_360-degree_Views_ICCV_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: Y0pCki6q_DkC
+  - key: bevclip2024
+    title: "Bev-clip: Multi-modal bev retrieval methodology for complex scene in autonomous
+      driving"
+    authors: Z Jia, T Gao, C Cai, C Hou, P Jia, F JingChen, Y ZHAO, K Zhan, FU LIU,
+      ...[24](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17455078764301502962)2024
+    year: "2024"
+    venue: ""
+    citation_count: 24
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:0EnyYjriUFMC
+    external_url: https://openreview.net/forum?id=wlqkRFRkYc
+    pdf_url: https://openreview.net/pdf?id=wlqkRFRkYc
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 0EnyYjriUFMC
+  - key: generalizing2024
+    title: Generalizing motion planners with mixture of experts for autonomous driving
+    authors: Q Sun, H Wang, J Zhan, F Nie, X Wen, L Xu, K Zhan, P Jia, X Lang, ...
+    year: "2025"
+    venue: IEEE International Conference on Robotics and Automation (ICRA), 6033-6039
+      [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8525832948576027576
+    citation_count: 23
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_FxGoFyzp5QC
+    external_url: https://ieeexplore.ieee.org/abstract/document/11127274/
+    pdf_url: https://arxiv.org/pdf/2410.15774?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: _FxGoFyzp5QC
+  - key: thebetter2025
+    title: "The better you learn, the smarter you prune: Towards efficient vision-language-action
+      models via differentiable token pruning"
+    authors: T Jiang, X Jiang, Y Ma, X Wen, B Li, K Zhan, P Jia, Y Liu, S Sun, X Lang
+    year: "2025"
+    venue: arXiv preprint arXiv:2509.12594 [23](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9527737081615138439
+    citation_count: 22
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:aqlVkmm33-oC
+    external_url: https://arxiv.org/abs/2509.12594
+    pdf_url: https://arxiv.org/pdf/2509.12594?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: aqlVkmm33-oC
+  - key: transdiffuser2025
+    title: "Transdiffuser: End-to-end trajectory generation with decorrelated multi-modal
+      representation for autonomous driving"
+    authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, XP Lang, S Sun
+    year: "2025"
+    venue: "arXiv e-prints, arXiv: 2505.09315 [22](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7007766532717179773"
+    citation_count: 21
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Zph67rFs4hoC
+    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250509315J/abstract
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: Zph67rFs4hoC
+  - key: bevtsr2025
+    title: "Bev-tsr: Text-scene retrieval in bev space for autonomous driving"
+    authors: T Tang, D Wei, Z Jia, T Gao, C Cai, C Hou, P Jia, K Zhan, H Sun, ...
+    year: "2025"
+    venue: Proceedings of the AAAI Conference on Artificial Intelligence 39 (7), 7275-7283
+      [19](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8013861478970669481
+    citation_count: 17
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:eQOLeE2rZwMC
+    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/32782
+    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/32782/34937
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: eQOLeE2rZwMC
+  - key: joint2015
+    title: Joint tracking and classification with constraints and reassignment by radar
+      and ESM
+    authors: H Jiang, K Zhan, L Xu
+    year: "2015"
+    venue: Digital Signal Processing 40, 213-223 [17](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2198228601778586949
+    citation_count: 17
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:2osOgNQ5qMEC
+    external_url: https://www.sciencedirect.com/science/article/pii/S105120041500024X
+    pdf_url: https://www.researchgate.net/profile/Kun-Zhan-4/publication/272522907_Joint_tracking_and_classification_with_constraints_and_reassignment_by_radar_and_ESM/links/5dd4aa18458515cd48ac0bc6/Joint-tracking-and-classification-with-constraints-and-reassignment-by-radar-and-ESM.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 2osOgNQ5qMEC
+  - key: geodrive2025
+    title: "Geodrive: 3d geometry-informed driving world model with precise action control"
+    authors: A Chen, W Zheng, Y Wang, X Zhang, K Zhan, P Jia, K Keutzer, S Zhang
+    year: "2025"
+    venue: arXiv preprint arXiv:2505.22421 [16](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15666192644711815204
+    citation_count: 15
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YOwf2qJgpHMC
+    external_url: https://arxiv.org/abs/2505.22421
+    pdf_url: https://arxiv.org/pdf/2505.22421
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: YOwf2qJgpHMC
+  - key: joint2014
+    title: Joint tracking and classification based on aerodynamic model and radar cross
+      section
+    authors: H Jiang, L Xu, K Zhan
+    year: "2014"
+    venue: Pattern recognition 47 (9), 3096-3105 [15](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7434382400669015995
+    citation_count: 15
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qjMakFHDy7sC
+    external_url: https://www.sciencedirect.com/science/article/pii/S0031320314000715
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: qjMakFHDy7sC
+  - key: balanced2024
+    title: "Balanced 3DGS: Gaussian-wise parallelism rendering with fine-grained tiling"
+    authors: H Gui, L Hu, R Chen, M Huang, Y Yin, J Yang, Y Wu, C Liu, Z Sun, ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2412.17378 [13](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6928535925966535687
+    citation_count: 12
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:roLk4NBRz8UC
+    external_url: https://arxiv.org/abs/2412.17378
+    pdf_url: https://arxiv.org/pdf/2412.17378?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: roLk4NBRz8UC
+  - key: street2023
+    title: Street gaussians for modeling dynamic urban scenes.(2023)
+    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+    year: "2023"
+    venue: arXiv preprint arXiv:2401.01339 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2617111234141021442
+    citation_count: 11
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:5nxA0vEk-isC
+    external_url: https://scholar.google.com/scholar?cluster=2617111234141021442&hl=en&oi=scholarr
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 5nxA0vEk-isC
+  - key: worldrftlatent2026
+    title: "WorldRFT: Latent world model planning with reinforcement fine-tuning for
+      autonomous driving"
+    authors: P Yang, B Lu, Z Xia, C Han, Y Gao, T Zhang, K Zhan, XP Lang, Y Zheng, ...
+    year: "2026"
+    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (14), 11649…
+      [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10655084415478563555
+    citation_count: 10
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hC7cP41nSMkC
+    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/38149
+    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/38149/42111
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: hC7cP41nSMkC
+  - key: discretediffusion2025
+    title: Discrete diffusion for reflective vision-language-action models in autonomous
+      driving
+    authors: P Li, Y Zheng, Y Wang, H Wang, H Zhao, J Liu, X Zhan, K Zhan, X Lang
+    year: "2025"
+    venue: arXiv preprint arXiv:2509.20109 [12](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11599180194041497583
+    citation_count: 10
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Wp0gIr-vW9MC
+    external_url: https://arxiv.org/abs/2509.20109
+    pdf_url: https://arxiv.org/pdf/2509.20109?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: Wp0gIr-vW9MC
+  - key: driveagentr120252
+    title: "DriveAgent-R1: Advancing VLM-based autonomous driving with hybrid thinking
+      and active perception"
+    authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
+    year: "2025"
+    venue: "arXiv e-prints, arXiv: 2507.20879 [11](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13273096394978228899"
+    citation_count: 9
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qxL8FJ1GzNcC
+    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250720879Z/abstract
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: qxL8FJ1GzNcC
+  - key: uatrack2024
+    title: "Ua-track: Uncertainty-aware end-to-end 3d multi-object tracking"
+    authors: L Zhou, T Tang, P Hao, Z He, K Ho, S Gu, W Hou, Z Hao, H Sun, K Zhan, ...
+    year: "2024"
+    venue: "arXiv e-prints, arXiv: 2406.02147 [10](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=15720233251267028580"
+    citation_count: 9
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:WF5omc3nYNoC
+    external_url: https://scholar.google.com/scholar?cluster=15720233251267028580&hl=en&oi=scholarr
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: WF5omc3nYNoC
+  - key: dive1961
+    title: "Dive: Efficient multi-view driving scenes generation based on video diffusion
+      transformer"
+    authors: J Jiang, G Hong, M Zhang, H Hu, K Zhan, R Shao, L Nie
+    year: "2025"
+    venue: arXiv preprint arXiv:2504.19614 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17699301463624196526
+    citation_count: 6
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:3fE2CSJIrl8C
+    external_url: https://arxiv.org/abs/2504.19614
+    pdf_url: https://arxiv.org/pdf/2504.19614
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 3fE2CSJIrl8C
+  - key: adr12025
+    title: "AD-R1: Closed-Loop Reinforcement Learning for End-to-End Autonomous Driving
+      with Impartial World Models"
+    authors: T Yan, T Tang, X Gui, Y Li, J Zhesng, W Huang, L Kong, W Han, X Zhou, ...
+    year: "2025"
+    venue: arXiv preprint arXiv:2511.20325 [9](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12225875259442502649
+    citation_count: 6
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IWHjjKOFINEC
+    external_url: https://arxiv.org/abs/2511.20325
+    pdf_url: https://arxiv.org/pdf/2511.20325
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: IWHjjKOFINEC
+  - key: xiaoxiaolong2024
+    title: "Xiaoxiao Long, Yilun Chen, and Hao Zhao. Tod3cap: Towards 3d dense captioning
+      in outdoor scenes"
+    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+      ...
+    year: "2024"
+    venue: Computer Vision–ECCV, 367-384 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7647393139940744594
+    citation_count: 6
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:M3ejUd6NZC8C
+    external_url: https://scholar.google.com/scholar?cluster=7647393139940744594&hl=en&oi=scholarr
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: M3ejUd6NZC8C
+  - key: joint20142
+    title: Joint tracking and classification on aerodynamic model and RCS by ground-based
+      passive radar
+    authors: L Xu, K Zhan, H Jiang, L Bai, M Wu
+    year: "2014"
+    venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
+      [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1850746215740028633
+    citation_count: 6
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:9yKSN-GCB0IC
+    external_url: https://ieeexplore.ieee.org/abstract/document/7007306/
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 9yKSN-GCB0IC
+  - key: robopearls2025
+    title: "RoboPearls: editable video simulation for robot manipulation"
+    authors: T Tao, L Zhang, Y Wen, K Zhang, JW Bian, X Zhou, T Yan, K Zhan, P Jia,
+      ...
+    year: "2025"
+    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+      [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=2125478236741172501
+    citation_count: 5
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_kc_bZDykSQC
+    external_url: https://doi.org/10.48550/arXiv.2506.22756
+    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Tao_RoboPearls_Editable_Video_Simulation_for_Robot_Manipulation_ICCV_2025_paper.pdf
+    doi: 10.48550/arXiv.2506.22756
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: _kc_bZDykSQC
+  - key: s2track2024
+    title: "S2-track: A simple yet strong approach for end-to-end 3d multi-object tracking"
+    authors: T Tang, L Zhou, P Hao, Z He, K Ho, S Gu, Z Hao, H Sun, K Zhan, P Jia, ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2406.02147 [6](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=6393263639948240409
+    citation_count: 5
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ULOm3_A8WrAC
+    external_url: https://arxiv.org/abs/2406.02147
+    pdf_url: https://arxiv.org/pdf/2406.02147
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: ULOm3_A8WrAC
+  - key: rlgf2025
+    title: "Rlgf: Reinforcement learning with geometric feedback for autonomous driving
+      video generation"
+    authors: T Yan, W Han, X Zhang, K Zhan, CZ Xu, J Shen
+    year: "2026"
+    venue: Advances in Neural Information Processing Systems 38, 128659-128684 [8](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=164477913199947917
+    citation_count: 4
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4DMP91E08xMC
+    external_url: https://doi.org/10.48550/arXiv.2509.16500
+    pdf_url: https://arxiv.org/pdf/2509.16500
+    doi: 10.48550/arXiv.2509.16500
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 4DMP91E08xMC
+  - key: evolvingfrom2026
+    title: Evolving from Tool User to Creator via Training-Free Experience Reuse in
+      Multimodal Reasoning
+    authors: X Shen, J Chen, L Zheng, H Ma, T Wei, K Zhan
+    year: "2026"
+    venue: arXiv preprint arXiv:2602.01983 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=7889678616000217910
+    citation_count: 4
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hFOr9nPyWt4C
+    external_url: https://arxiv.org/abs/2602.01983
+    pdf_url: https://arxiv.org/pdf/2602.01983
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: hFOr9nPyWt4C
+  - key: posepilot2025
+    title: "PosePilot: Steering camera pose for generative world models with self-supervised
+      depth"
+    authors: B Jin, W Li, B Yang, Z Zhu, J Jiang, H Gao, H Sun, K Zhan, H Hu, X Zhang,
+      ...
+    year: "2025"
+    venue: IEEE/RSJ International Conference on Intelligent Robots and Systems… [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10498075774223536829
+    citation_count: 4
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:kNdYIx-mwKoC
+    external_url: https://ieeexplore.ieee.org/abstract/document/11247293/
+    pdf_url: https://arxiv.org/pdf/2505.01729
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: kNdYIx-mwKoC
+  - key: transdiffuserdiverse2025
+    title: "Transdiffuser: Diverse trajectory generation with decorrelated multi-modal
+      representation for end-to-end autonomous driving"
+    authors: X Jiang, Y Ma, P Li, L Xu, X Wen, K Zhan, Z Xia, P Jia, X Lang, S Sun
+    year: "2025"
+    venue: arXiv preprint arXiv:2505.09315 [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=12624178323067622969
+    citation_count: 3
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:HDshCWvjkbEC
+    external_url: https://arxiv.org/abs/2505.09315
+    pdf_url: https://arxiv.org/pdf/2505.09315
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: HDshCWvjkbEC
+  - key: omnigen2025
+    title: "Omnigen: Unified multimodal sensor generation for autonomous driving"
+    authors: T Tang, E Ma, X Zhou, L Wang, T Yan, X Zhang, K Zhan, P Jia, X Lang, ...
+    year: "2025"
+    venue: Proceedings of the 33rd ACM International Conference on Multimedia, 9365-9374
+      [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=3797374454920276086
+    citation_count: 3
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mVmsd5A6BfQC
+    external_url: https://doi.org/10.48550/arXiv.2512.14225
+    pdf_url: https://dl.acm.org/doi/pdf/10.1145/3746027.3754772
+    doi: 10.48550/arXiv.2512.14225
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: mVmsd5A6BfQC
+  - key: learningpersonalized2025
+    title: Learning Personalized Driving Styles via Reinforcement Learning from Human
+      Feedback
+    authors: D Li, C Li, Y Wang, J Ren, X Wen, P Li, L Xu, K Zhan, P Jia, X Lang, N
+      Xu, ...
+    year: "2025"
+    venue: arXiv preprint arXiv:2503.10434 [4](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8047799359356458182
+    citation_count: 3
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:mB3voiENLucC
+    external_url: https://arxiv.org/abs/2503.10434
+    pdf_url: https://arxiv.org/pdf/2503.10434
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: mB3voiENLucC
+  - key: driveagentr12025
+    title: "DriveAgent-R1: Advancing VLM-based Autonomous Driving with Active Perception
+      and Hybrid Thinking"
+    authors: W Zheng, X Mao, N Ye, P Li, K Zhan, X Lang, H Zhao
+    year: "2025"
+    venue: arXiv preprint arXiv:2507.20879 [5](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=5635847788066915044,17179949796365284237
+    citation_count: 3
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:dhFuZR0502QC
+    external_url: https://arxiv.org/abs/2507.20879
+    pdf_url: https://arxiv.org/pdf/2507.20879
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: dhFuZR0502QC
+  - key: particle2014
+    title: Particle filter based joint tracking and classification
+    authors: K Zhan, L Xu, H Jiang, L Bai, M Wu
+    year: "2014"
+    venue: Proceedings of IEEE Chinese Guidance, Navigation and Control Conference…
+      [3](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=11948931031763077540
+    citation_count: 3
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UeHWp8X0CEIC
+    external_url: https://ieeexplore.ieee.org/abstract/document/7007307/
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: UeHWp8X0CEIC
+  - key: correctada2026
+    title: "Correctad: A self-correcting agentic system to improve end-to-end planning
+      in autonomous driving"
+    authors: E Ma, L Zhou, T Tang, J Zhang, J Jiang, Z Zhang, D Han, K Zhan, X Zhang,
+      ...
+    year: "2026"
+    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (10), 7755-7763
+      [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9391779730238116875
+    citation_count: 1
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:7PzlFSSx8tAC
+    external_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718
+    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/view/37718/41680
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 7PzlFSSx8tAC
+  - key: styledstreets2025
+    title: "StyledStreets: Multi-style Street Simulator with Spatial and Temporal Consistency"
+    authors: Y Chen, Y Wang, X Zhang, K Zhan, P Jia, Y Zhan, X Lang
+    year: "2025"
+    venue: arXiv preprint arXiv:2503.21104 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=36853680135788572
+    citation_count: 1
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:hqOjcs7Dif8C
+    external_url: https://arxiv.org/abs/2503.21104
+    pdf_url: https://arxiv.org/pdf/2503.21104?
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: hqOjcs7Dif8C
+  - key: unifyinglanguage2026
+    title: Unifying language-action understanding and generation for autonomous driving
+    authors: X Wang, Q Liu, W Ding, Z Yang, W Li, C Liu, B Li, K Zhan, X Lang, ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.01441 [2](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14545021791743234404
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:e5wmG9Sq2KIC
+    external_url: https://arxiv.org/abs/2603.01441
+    pdf_url: https://arxiv.org/pdf/2603.01441
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: e5wmG9Sq2KIC
+  - key: streetforwardperceiving2026
+    title: "StreetForward: Perceiving Dynamic Street with Feedforward Causal Attention"
+    authors: Z Yu, Z Wang, Y Xie, Y Wang, X Zhang, Y Zhan, K Zhan
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.19552 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:j3f4tGmQtD8C
+    external_url: https://arxiv.org/abs/2603.19552
+    pdf_url: https://arxiv.org/pdf/2603.19552
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: j3f4tGmQtD8C
+  - key: streamingclawtechnical2026
+    title: StreamingClaw Technical Report
+    authors: J Chen, Z Chen, C Du, M He, W He, H Li, Q Li, Z Liu, H Ma, X Pan, C Ren,
+      ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.22120 [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14090650148033921883
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:RHpTSmoSYBkC
+    external_url: https://arxiv.org/abs/2603.22120
+    pdf_url: https://arxiv.org/pdf/2603.22120
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: RHpTSmoSYBkC
+  - key: reflectdrive22026
+    title: "ReflectDrive-2: Reinforcement-Learning-Aligned Self-Editing for Discrete
+      Diffusion Driving"
+    authors: H Wang, Y Wang, B Cui, P Li, B Lu, M Wang, T Wang, C Tang, T Zhang, ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2605.04647 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
+    external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:bEWYMUwI8FkC
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: bEWYMUwI8FkC
+  - key: methodand2026
+    title: Method and apparatus for generating trajectory, electronic device, storage
+      medium
+    authors: B Li, K Zhan, P Jia, X Lang, Y Wang, J GU, Y Jiang, Q Jiang, S Zhao, ...
+    year: "2026"
+    venue: US Patent App. 19/037,583 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:-f6ydRqryjwC
+    external_url: https://patents.google.com/patent/US20260008479A1/en
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: -f6ydRqryjwC
+  - key: m2asynergizing2026
+    title: "M2A: Synergizing Mathematical and Agentic Reasoning in Large Language Models"
+    authors: J Wang, X Zhou, Q Xu, K Zhan
+    year: "2026"
+    venue: arXiv preprint arXiv:2605.09879 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
+    external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:iH-uZ7U-co4C
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: iH-uZ7U-co4C
+  - key: hardwareco2026
+    title: Hardware Co-Design Scaling Laws via Roofline Modelling for On-Device LLMs
+    authors: L Sun, J Jiang, Y Ding, F Li, Y Song, H Zhang, J Ying, L Ren, K Zhan, ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2602.10377 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:r0BpntZqJG4C
+    external_url: https://arxiv.org/abs/2602.10377
+    pdf_url: https://arxiv.org/pdf/2602.10377
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: r0BpntZqJG4C
+  - key: faarformat2026
+    title: "FAAR: Format-Aware Adaptive Rounding for NVFP4"
+    authors: H Li, S Tian, C Lin, Z Zhao, K Zhan
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.22370 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4JMBOYKVnBMC
+    external_url: https://arxiv.org/abs/2603.22370
+    pdf_url: https://arxiv.org/pdf/2603.22370
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 4JMBOYKVnBMC
+  - key: evaluatingthe2026
+    title: Evaluating the Search Agent in a Parallel World
+    authors: J Chen, X Shen, L Zheng, L Mu, H Sun, N Mao, H Ma, T Wei, P Zhou, ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.04751 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:_Qo2XoVZTnwC
+    external_url: https://arxiv.org/abs/2603.04751
+    pdf_url: https://arxiv.org/pdf/2603.04751
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: _Qo2XoVZTnwC
+  - key: drivelidar4d2025
+    title: "DriveLiDAR4D: Sequential and Controllable LiDAR Scene Generation for Autonomous
+      Driving"
+    authors: K Cai, X Liu, X Zhou, H Hu, J Xiang, L Zhang, X Zhang, K Zhan, Y Zhan,
+      ...
+    year: "2026"
+    venue: Proceedings of the AAAI Conference on Artificial Intelligence 40 (4), 2525-2533
+      [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ZeXyd9-uunAC
+    external_url: https://doi.org/10.48550/arXiv.2511.13309
+    pdf_url: https://ojs.aaai.org/index.php/AAAI/article/download/37239/41201
+    doi: 10.48550/arXiv.2511.13309
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: ZeXyd9-uunAC
+  - key: drivecombobenchmarking2026
+    title: "DriveCombo: Benchmarking Compositional Traffic Rule Reasoning in Autonomous
+      Driving"
+    authors: E Ma, J Zhang, G Zheng, T Tang, SE Li, Y Lu, X Zhou, X Zhang, Y Zhan, ...
+    year: "2026"
+    venue: arXiv preprint arXiv:2603.01637 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:R3hNpaxXUhUC
+    external_url: https://arxiv.org/abs/2603.01637
+    pdf_url: https://arxiv.org/pdf/2603.01637
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: R3hNpaxXUhUC
+  - key: closedloop2026
+    title: Closed Loop Dynamic Driving Data Mixture for Real-Synthetic Co-Training
+    authors: H Ruan, P Liu, W Ma, Z Li, X Zhang, J Ma, D Xu, K Zhan
+    year: "2026"
+    venue: arXiv preprint arXiv:2605.21372 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
+    external_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:TFP_iSt0sucC
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: TFP_iSt0sucC
+  - key: streetgaussians2025
+    title: "Street Gaussians: Modeling Dynamic Urban Scenes With Gaussian Primitives"
+    authors: S Peng, Y Long, Y Yan, H Lin, C Zhou, H Sun, K Zhan, X Lang, H Bao, ...
+    year: "2025"
+    venue: IEEE transactions on pattern analysis and machine intelligence [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:L8Ckcad2t8MC
+    external_url: https://ieeexplore.ieee.org/abstract/document/11260967/
+    pdf_url: https://drive.google.com/file/d/1NWpnbFzPnxyrFch9aCCbEZxLZn9xCjib/view
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: L8Ckcad2t8MC
+  - key: sparseworldtc2025
+    title: "SparseWorld-TC: Trajectory-Conditioned Sparse Occupancy World Model"
+    authors: J Du, Y Zhao, Z Guo, Y Pan, W Hou, Z Hao, K Zhan, Q Chen
+    year: "2025"
+    venue: arXiv preprint arXiv:2511.22039 [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:qUcmZB5y_30C
+    external_url: https://arxiv.org/abs/2511.22039
+    pdf_url: https://arxiv.org/pdf/2511.22039
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: qUcmZB5y_30C
+  - key: hineushigh2025
+    title: "HiNeuS: High-fidelity Neural Surface Mitigating Low-texture and Reflective
+      Ambiguity"
+    authors: Y Wang, X Zhang, K Zhan, P Jia, X Lang
+    year: "2025"
+    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+      [](http://scholar.google.com/citations?user=1J061HIAAAAJ&hl=en&cstart=0&pagesize=100&sortby=pubdate
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:4TOpqqG69KYC
+    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Wang_HiNeuS_High-fidelity_Neural_Surface_Mitigating_Low-texture_and_Reflective_Ambiguity_ICCV_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: 4TOpqqG69KYC
+  - key: hierarchyugp2025
+    title: "Hierarchy UGP: Hierarchy Unified Gaussian Primitive for Large-Scale Dynamic
+      Scene Reconstruction"
+    authors: H Sun, Q Yang, J Wang, Z Xu, C Liu, Y Wang, K Zhan, H Bao, X Zhou, ...
+    year: "2025"
+    venue: Proceedings of the IEEE/CVF International Conference on Computer Vision…
+      [1](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=16823791912791942975
+    citation_count: null
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:QIV2ME_5wuYC
+    external_url: https://openaccess.thecvf.com/content/ICCV2025/html/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/ICCV2025/papers/Sun_Hierarchy_UGP_Hierarchy_Unified_Gaussian_Primitive_for_Large-Scale_Dynamic_Scene_ICCV_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: ""
+    google_scholar_id: QIV2ME_5wuYC
 top_publications:
-- key: drivevlm2024
-  title: 'Drivevlm: The convergence of autonomous driving and large vision-language
-    models'
-  authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
-  year: '2024'
-  venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
-  citation_count: 562
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
-  external_url: https://arxiv.org/abs/2402.12289
-  pdf_url: https://arxiv.org/pdf/2402.12289
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/drivevlm2024.png
-  google_scholar_id: zYLM7Y9cAGgC
-- key: street2024
-  title: 'Street gaussians: Modeling dynamic urban scenes with gaussian splatting'
-  authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
-  year: '2024'
-  venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
-  citation_count: 406
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
-  external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
-  pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/street2024-preview.png
-  google_scholar_id: IjCSPb-OGe4C
-- key: recondreamer2025
-  title: 'Recondreamer: Crafting world models for driving scene reconstruction via
-    online restoration'
-  authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
-    [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
-  citation_count: 86
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/recondreamer2025-pdf-preview.png
-  google_scholar_id: LkGwnXOMwfcC
-- key: planagent2024
-  title: 'Planagent: A multi-modal large language agent for closed-loop vehicle motion
-    planning'
-  authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
-  year: '2026'
-  venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
-  citation_count: 55
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
-  external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
-  pdf_url: https://arxiv.org/pdf/2406.01587
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/planagent2024-pdf-preview.png
-  google_scholar_id: Tyk-4Ss8FVUC
-- key: unleashing2024
-  title: Unleashing generalization of end-to-end autonomous driving with controllable
-    long video generation
-  authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
-  citation_count: 51
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
-  external_url: https://arxiv.org/abs/2406.01349
-  pdf_url: https://arxiv.org/pdf/2406.01349
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/unleashing2024-pdf-preview.png
-  google_scholar_id: W7OEmFMy1HYC
-- key: streetcrafter2025
-  title: 'Streetcrafter: Street view synthesis with controllable video diffusion models'
-  authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
-    ...
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
-    [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
-  citation_count: 43
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/streetcrafter2025-pdf-preview.jpeg
-  google_scholar_id: Se3iqnhoufwC
-- key: tod3cap2024
-  title: 'Tod3cap: Towards 3d dense captioning in outdoor scenes'
-  authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
-    ...
-  year: '2024'
-  venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
-  citation_count: 42
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
-  external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
-  pdf_url: https://arxiv.org/pdf/2403.19589?
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/tod3cap2024-pdf-preview.jpeg
-  google_scholar_id: ufrVoPGSRksC
-- key: drivingsphere2025
-  title: 'Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation'
-  authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
-  year: '2025'
-  venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
-    [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
-  citation_count: 32
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
-  external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
-  pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/drivingsphere2025-pdf-preview.jpeg
-  google_scholar_id: UebtZRa9Y70C
-- key: finetuning2025
-  title: Finetuning generative trajectory model with reinforcement learning from human
-    feedback
-  authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
-    Xu, ...
-  year: '2025'
-  venue: 'arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741'
-  citation_count: 31
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
-  external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
-  pdf_url: ''
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/finetuning2025-preview.png
-  google_scholar_id: MXK_kJrjxJIC
-- key: dive2024
-  title: 'Dive: Dit-based video generation with enhanced control'
-  authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
-    ...
-  year: '2024'
-  venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
-  citation_count: 31
-  scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
-  external_url: https://arxiv.org/abs/2409.01595
-  pdf_url: https://arxiv.org/pdf/2409.01595
-  doi: ''
-  arxiv: ''
-  preview_image: /assets/img/publication_preview/dive2024-pdf-preview.jpeg
-  google_scholar_id: YsMSGLbcyi4C
+  - key: drivevlm2024
+    title: "Drivevlm: The convergence of autonomous driving and large vision-language
+      models"
+    authors: X Tian, J Gu, B Li, Y Liu, Y Wang, Z Zhao, K Zhan, P Jia, X Lang, H Zhao
+    year: "2024"
+    venue: arXiv preprint arXiv:2402.12289 [599](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9069990263513405041
+    citation_count: 562
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:zYLM7Y9cAGgC
+    external_url: https://arxiv.org/abs/2402.12289
+    pdf_url: https://arxiv.org/pdf/2402.12289
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/drivevlm2024.png
+    google_scholar_id: zYLM7Y9cAGgC
+  - key: street2024
+    title: "Street gaussians: Modeling dynamic urban scenes with gaussian splatting"
+    authors: Y Yan, H Lin, C Zhou, W Wang, H Sun, K Zhan, X Lang, X Zhou, S Peng
+    year: "2024"
+    venue: European Conference on Computer Vision, 156-173 [426](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8138670866186059561
+    citation_count: 406
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:IjCSPb-OGe4C
+    external_url: https://link.springer.com/chapter/10.1007/978-3-031-73464-9_10
+    pdf_url: https://drive.google.com/file/d/1oX7YhBlVWORrUq1n2LLVgP5sTwDnepjL/view
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/street2024-preview.png
+    google_scholar_id: IjCSPb-OGe4C
+  - key: recondreamer2025
+    title: "Recondreamer: Crafting world models for driving scene reconstruction via
+      online restoration"
+    authors: C Ni, G Zhao, X Wang, Z Zhu, W Qin, G Huang, C Liu, Y Chen, Y Wang, ...
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 1559-1569
+      [87](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10376473717473330982
+    citation_count: 86
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:LkGwnXOMwfcC
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Ni_ReconDreamer_Crafting_World_Models_for_Driving_Scene_Reconstruction_via_Online_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/recondreamer2025-pdf-preview.png
+    google_scholar_id: LkGwnXOMwfcC
+  - key: planagent2024
+    title: "Planagent: A multi-modal large language agent for closed-loop vehicle motion
+      planning"
+    authors: Y Zheng, Z Xing, Q Zhang, B Jin, P Li, Y Zheng, Z Xia, Y Chen, D Zhao
+    year: "2026"
+    venue: IEEE Transactions on Cognitive and Developmental Systems [62](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=4421753326440065257
+    citation_count: 55
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Tyk-4Ss8FVUC
+    external_url: https://ieeexplore.ieee.org/abstract/document/11394788/
+    pdf_url: https://arxiv.org/pdf/2406.01587
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/planagent2024-pdf-preview.png
+    google_scholar_id: Tyk-4Ss8FVUC
+  - key: unleashing2024
+    title: Unleashing generalization of end-to-end autonomous driving with controllable
+      long video generation
+    authors: E Ma, L Zhou, T Tang, Z Zhang, D Han, J Jiang, K Zhan, P Jia, X Lang, ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2406.01349 [56](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=8558179969649046939
+    citation_count: 51
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:W7OEmFMy1HYC
+    external_url: https://arxiv.org/abs/2406.01349
+    pdf_url: https://arxiv.org/pdf/2406.01349
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/unleashing2024-pdf-preview.png
+    google_scholar_id: W7OEmFMy1HYC
+  - key: streetcrafter2025
+    title: "Streetcrafter: Street view synthesis with controllable video diffusion models"
+    authors: Y Yan, Z Xu, H Lin, H Jin, H Guo, Y Wang, K Zhan, X Lang, H Bao, X Zhou,
+      ...
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 822-832
+      [45](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=10025705900330225678
+    citation_count: 43
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:Se3iqnhoufwC
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_StreetCrafter_Street_View_Synthesis_with_Controllable_Video_Diffusion_Models_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/streetcrafter2025-pdf-preview.jpeg
+    google_scholar_id: Se3iqnhoufwC
+  - key: tod3cap2024
+    title: "Tod3cap: Towards 3d dense captioning in outdoor scenes"
+    authors: B Jin, Y Zheng, P Li, W Li, Y Zheng, S Hu, X Liu, J Zhu, Z Yan, H Sun,
+      ...
+    year: "2024"
+    venue: European Conference on Computer Vision, 367-384 [44](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=17399025554193074791
+    citation_count: 42
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:ufrVoPGSRksC
+    external_url: https://link.springer.com/chapter/10.1007/978-3-031-72649-1_21
+    pdf_url: https://arxiv.org/pdf/2403.19589?
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/tod3cap2024-pdf-preview.jpeg
+    google_scholar_id: ufrVoPGSRksC
+  - key: drivingsphere2025
+    title: "Drivingsphere: Building a high-fidelity 4d world for closed-loop simulation"
+    authors: T Yan, D Wu, W Han, J Jiang, X Zhou, K Zhan, C Xu, J Shen
+    year: "2025"
+    venue: Proceedings of the Computer Vision and Pattern Recognition Conference, 27531…
+      [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=1178226343426138884
+    citation_count: 32
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:UebtZRa9Y70C
+    external_url: https://openaccess.thecvf.com/content/CVPR2025/html/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.html
+    pdf_url: https://openaccess.thecvf.com/content/CVPR2025/papers/Yan_DrivingSphere_Building_a_High-fidelity_4D_World_for_Closed-loop_Simulation_CVPR_2025_paper.pdf
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/drivingsphere2025-pdf-preview.jpeg
+    google_scholar_id: UebtZRa9Y70C
+  - key: finetuning2025
+    title: Finetuning generative trajectory model with reinforcement learning from human
+      feedback
+    authors: D Li, J Ren, Y Wang, X Wen, P Li, L Xu, K Zhan, Z Xia, P Jia, X Lang, N
+      Xu, ...
+    year: "2025"
+    venue: "arXiv e-prints, arXiv: 2503.10434 [31](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=14639323362602446741"
+    citation_count: 31
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:MXK_kJrjxJIC
+    external_url: https://ui.adsabs.harvard.edu/abs/2025arXiv250310434L/abstract
+    pdf_url: ""
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/finetuning2025-preview.png
+    google_scholar_id: MXK_kJrjxJIC
+  - key: dive2024
+    title: "Dive: Dit-based video generation with enhanced control"
+    authors: J Jiang, G Hong, L Zhou, E Ma, H Hu, X Zhou, J Xiang, F Liu, K Yu, H Sun,
+      ...
+    year: "2024"
+    venue: arXiv preprint arXiv:2409.01595 [32](https://scholar.google.com/scholar?oi=bibs&hl=en&cites=13549890270565481597
+    citation_count: 31
+    scholar_url: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=1J061HIAAAAJ&citation_for_view=1J061HIAAAAJ:YsMSGLbcyi4C
+    external_url: https://arxiv.org/abs/2409.01595
+    pdf_url: https://arxiv.org/pdf/2409.01595
+    doi: ""
+    arxiv: ""
+    preview_image: /assets/img/publication_preview/dive2024-pdf-preview.jpeg
+    google_scholar_id: YsMSGLbcyi4C

--- a/_posts/2015-10-20-math.md
+++ b/_posts/2015-10-20-math.md
@@ -26,4 +26,4 @@ MathJax will automatically number equations:
 
 and by adding `\label{...}` inside the equation environment, we can now refer to the equation using `\eqref`.
 
-Note that MathJax 3 is [a major re-write of MathJax](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html) that brought a significant improvement to the loading and rendering speed, which is now [on par with KaTeX](http://www.intmath.com/cg5/katex-mathjax-comparison.php).
+Note that MathJax 3 is [a major re-write of MathJax](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html) that brought a significant improvement to the loading and rendering speed, which is now [on par with KaTeX](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html).

--- a/_posts/2018-12-22-distill.md
+++ b/_posts/2018-12-22-distill.md
@@ -93,7 +93,7 @@ $$
 \left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
 $$
 
-Note that MathJax 3 is [a major re-write of MathJax](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html) that brought a significant improvement to the loading and rendering speed, which is now [on par with KaTeX](http://www.intmath.com/cg5/katex-mathjax-comparison.php).
+Note that MathJax 3 is [a major re-write of MathJax](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html) that brought a significant improvement to the loading and rendering speed, which is now [on par with KaTeX](https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Refresh the homepage publication snapshot and citation metrics from Google Scholar for scholar user `1J061HIAAAAJ` to keep the site’s publication cards and citation counters up to date.
- Ensure the local bibliography used for rendering and citation links is synchronized with the latest Scholar-exported metadata.

### Description
- Ran `python bin/update_scholar.py` to fetch the latest Scholar snapshot (script reported updating 57 publications) and updated `_data/scholar.yml` including `profile` stats, `publications` list, and `updated_at` timestamp.
- Synchronized `_bibliography/papers.bib` with the newest entries and metadata (titles, authors, years, notes, google_scholar_id, preview/thumbnail fields, and citation counts) and normalized several note/index values.
- Committed the changes with the message `Update homepage publications from Google Scholar`.

### Testing
- Ran the automated test suite `pytest -q tests/test_update_scholar.py` which completed successfully (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e1effa0c832593d6b40b99d145f3)