### PR TITLE
Update English homepage for Mach VLA, Mach Mind, and Livis Day

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,16 +1,19 @@
 ---
 layout: about
-title: Kun Zhan | Li Auto VLA
+title: "Kun Zhan | Li Auto Foundation Models & Autonomous Driving"
 permalink: /
 lang: en
-subtitle: Head of Foundation Model Team at <a href='https://www.lixiang.com/'>Li Auto</a>
-description: Kun Zhan is Head of the Foundation Model Team at Li Auto, leading the R&D of VLA models, self-developed chip fusion, and mass-production autonomous-driving systems.
+subtitle: "Head of Foundation Models &amp; Autonomous Driving at <a href='https://www.lixiang.com/'>Li Auto</a>"
+description: "Kun Zhan leads Li Auto's foundation model and autonomous driving teams, driving Mach VLA, Mach Mind-Pro, Mach Mind-Edge, and production-grade embodied-intelligence systems."
 keywords:
   - Kun Zhan
   - Li Auto
+  - Mach VLA
+  - Mach Mind
   - Vision-Language-Action
   - Autonomous Driving
-  - AI Leadership
+  - Embodied Intelligence
+  - Livis Day
 
 profile:
   align: right
@@ -36,11 +39,11 @@ latest_posts:
 ---
 <section class="about-hero">
   <div class="about-hero__content">
-    <span class="about-kicker">Foundation Models for Physical Intelligence</span>
-    <h2>Building embodied intelligence from autonomous driving to robotics</h2>
+    <span class="about-kicker">Foundation Models for Embodied Intelligence</span>
+    <h2>Building the vehicle-scale AI stack from perception to language to action</h2>
     <p>
-      I lead Li Auto's MindVLA and MindGPT teams, spanning behavior intelligence, cognitive intelligence, and
-      production-grade deployment across autonomous driving, smart cabin, and future embodied systems.
+      I lead Li Auto's foundation-model and autonomous-driving efforts, building the Mach VLA and Mach Mind model
+      families and deploying them across production vehicles as reliable physical-world intelligence systems.
     </p>
   </div>
 
@@ -72,20 +75,24 @@ latest_posts:
 <section class="about-section">
   <h2>About Me</h2>
   <p>
-    I'm <strong>Kun Zhan</strong>, leading Li Auto's MindVLA and MindGPT teams while also serving as Site Manager for
-    the company's Silicon Valley R&amp;D center. My work spans behavior intelligence and cognitive intelligence, building
-    foundation models for autonomous-driving VLA, smart-cabin LLM/VLM, and speech systems, then pushing them into
-    production with automotive-grade reliability.
+    I'm <strong>Kun Zhan</strong>, Head of Foundation Models and Autonomous Driving at Li Auto. My work focuses on
+    unifying machine intelligence and language intelligence into production-grade embodied systems: <strong>Mach VLA</strong>
+    for three-dimensional perception, decision, and action, and <strong>Mach Mind-Pro</strong> / <strong>Mach Mind-Edge</strong>
+    for cloud and on-device agentic reasoning.
   </p>
   <p>
-    My journey began with a master's degree in Automation from Beihang University, followed by leading Baidu Apollo's
-    behavior prediction team. Since joining Li Auto in 2021, I have been responsible for architecting and deploying
-    three generations of autonomous-driving stacks, evolving toward a unified framework that connects perception,
-    reasoning, planning, and action, and scales from driving to broader embodied systems.
+    Since joining Li Auto in 2021, I have been responsible for core autonomous-driving architecture evolution, from
+    Highway NoA and City NoA to end-to-end, VLM-assisted, and VLA-based systems. Today my agenda spans model research,
+    data engines, reinforcement learning, world models, chip-model co-design, on-vehicle inference, and OTA deployment
+    at automotive scale.
+  </p>
+  <p>
+    Earlier, I earned a master's degree in Automation from Beihang University and led behavior-prediction work at Baidu
+    Apollo, where I built large-scale motion-forecasting and planning systems for L4 autonomous-driving programs.
   </p>
   <blockquote class="about-quote">
-    My mission is to realize embodied, physical-world AGI using autonomous driving as the starting point and expanding
-    toward robotics and wider real-world intelligence.
+    My mission is to build physical-world AGI, using autonomous driving as the starting point and expanding toward
+    robots, intelligent spaces, and broader real-world embodied intelligence.
   </blockquote>
 </section>
 
@@ -93,30 +100,67 @@ latest_posts:
   <div class="about-section__header">
     <div>
       <h2>Key Highlights</h2>
-      <p>Leadership, production execution, and research translation at scale.</p>
+      <p>Leadership, model releases, and production execution across the full embodied-intelligence stack.</p>
     </div>
   </div>
 
   <div class="about-highlight-grid">
     <article class="about-highlight-card">
-      <h3>Scaled leadership</h3>
+      <h3>Unified AI leadership</h3>
       <p>
-        Lead Li Auto's Foundation Model organization across VLA, VLM, LLM, and World Models, covering research,
-        training infrastructure, deployment, and on-vehicle integration.
+        Lead Li Auto's foundation-model and autonomous-driving roadmap across Mach VLA, Mach Mind, 3D ViT, world
+        models, reinforcement learning, model infrastructure, and on-vehicle deployment.
       </p>
     </article>
     <article class="about-highlight-card">
-      <h3>Production impact</h3>
+      <h3>Mach model releases</h3>
       <p>
-        Delivered Highway NoA (2022), City NoA (2023), End-to-End + VLM dual-system (2024), and the new VLA stack
-        (2025) to mass-produced Li Auto vehicles.
+        Drove the release of the Mach VLA and Mach Mind-Pro / Mach Mind-Edge model families, connecting language
+        intelligence with machine intelligence for vehicles, cabins, and future embodied products.
       </p>
     </article>
     <article class="about-highlight-card">
-      <h3>Global execution</h3>
+      <h3>Full-stack production</h3>
       <p>
-        Built Li Auto's U.S. research hub and aligned Silicon Valley exploration with Beijing headquarters execution.
+        Translate research systems into user-facing capability through model-chip-OS-domain-controller integration,
+        including deployment paths around Li Auto's self-developed Mach M100 AI chip and Livis vehicles.
       </p>
+    </article>
+  </div>
+</section>
+
+<section class="about-section">
+  <div class="about-section__header">
+    <div>
+      <h2>Recent Milestones</h2>
+      <p>Public releases and talks that reflect the current direction of my work.</p>
+    </div>
+  </div>
+
+  <div class="about-highlight-grid">
+    <article class="about-highlight-card">
+      <h3>Livis Day keynote</h3>
+      <p>
+        Main speaker for Li Auto's software and embodied-intelligence launch, presenting the Mach model stack and the
+        path from intelligent vehicles to embodied-intelligence products.
+      </p>
+      <a class="about-link" href="https://www.youtube.com/watch?v=E8DX3SZcUfA">Watch event replay</a>
+    </article>
+    <article class="about-highlight-card">
+      <h3>Mach VLA</h3>
+      <p>
+        Announced the next evolution of Li Auto's VLA-based autonomous-driving architecture, scaling imitation learning,
+        reinforcement learning, model size, and compute for safer and more efficient real-world driving.
+      </p>
+      <a class="about-link" href="https://www.ithome.com/0/964/508.htm">Read launch coverage</a>
+    </article>
+    <article class="about-highlight-card">
+      <h3>Mach Mind</h3>
+      <p>
+        Released the Mach Mind-Pro and Mach Mind-Edge model family for cloud and on-device agentic intelligence, enabling
+        native vehicle control, multimodal interaction, and always-on local perception.
+      </p>
+      <a class="about-link" href="https://finance.sina.com.cn/tech/shenji/2026-06-16/doc-inicqhiw6274956.shtml">Read model coverage</a>
     </article>
   </div>
 </section>
@@ -130,12 +174,12 @@ latest_posts:
   </div>
 
   <div class="about-interest-grid">
-    <div class="about-interest-card"><strong>Autonomous Driving</strong><span>VLA models, end-to-end driving, planning, decision making</span></div>
-    <div class="about-interest-card"><strong>Computer Vision</strong><span>Detection, tracking, scene understanding, BEV perception</span></div>
-    <div class="about-interest-card"><strong>3D &amp; World Models</strong><span>Dynamic reconstruction, generative simulation, RL at fleet scale</span></div>
-    <div class="about-interest-card"><strong>Multimodal LLMs</strong><span>Reasoning, planning, and driver-vehicle interaction</span></div>
-    <div class="about-interest-card"><strong>Agent Models</strong><span>Reasoning to action with tool use, safety, and reliability</span></div>
-    <div class="about-interest-card"><strong>Robotics</strong><span>Embodied AI, humanoids, real-world manipulation and navigation</span></div>
+    <div class="about-interest-card"><strong>Physical-World Foundation Models</strong><span>VLA, world models, 3D ViT, RL, real-time decision and action</span></div>
+    <div class="about-interest-card"><strong>Autonomous Driving</strong><span>End-to-end driving, safety, planning, closed-loop deployment</span></div>
+    <div class="about-interest-card"><strong>Agentic LLM/VLM Systems</strong><span>Cloud and edge agents, tool use, multimodal interaction, driver-vehicle collaboration</span></div>
+    <div class="about-interest-card"><strong>AI Systems &amp; Chips</strong><span>Model-chip co-design, compiler/runtime, on-vehicle inference, cost-efficient deployment</span></div>
+    <div class="about-interest-card"><strong>Simulation &amp; Data Engines</strong><span>Fleet-scale data flywheels, synthetic data, closed-loop evaluation, training infrastructure</span></div>
+    <div class="about-interest-card"><strong>Robotics &amp; Embodied AI</strong><span>Generalization from vehicles to spatial intelligence, humanoids, manipulation, and navigation</span></div>
   </div>
 </section>
 
@@ -156,12 +200,13 @@ latest_posts:
         </div>
         <span>Beijing / San Jose</span>
       </div>
-      <div class="about-timeline-card__role">Head of Foundation Model Team</div>
+      <div class="about-timeline-card__role">Head of Foundation Models &amp; Autonomous Driving</div>
       <ul>
-        <li>Lead the R&amp;D of VLA foundation models and coordinate integration with self-developed autonomous-driving chips.</li>
-        <li>Built Li Auto's autonomous stack from E2E to VLM to VLA architectures operating on hundreds of thousands of vehicles.</li>
-        <li>Mentor a 100+ member organization across perception, planning, foundation models, simulation, and deployment.</li>
-        <li>Established dedicated world-model and RL groups to accelerate closed-loop learning and reduce real-world testing cost.</li>
+        <li>Lead Li Auto's foundation-model and autonomous-driving teams, unifying Mach VLA, Mach Mind, 3D ViT, world models, reinforcement learning, data infrastructure, and on-vehicle deployment.</li>
+        <li>Released the Mach VLA and Mach Mind-Pro / Mach Mind-Edge model series for embodied intelligence, with production integration into Livis vehicles and Li Auto's full-stack AI platform.</li>
+        <li>Drive chip-model co-design and mass-production deployment around self-developed AI chips, vehicle operating systems, and domain controllers.</li>
+        <li>Built Li Auto's autonomous-driving stack from Highway NoA and City NoA to E2E, VLM-assisted, and VLA-based architectures operating on hundreds of thousands of vehicles.</li>
+        <li>Mentor a 100+ member organization across perception, planning, foundation models, simulation, data, and deployment.</li>
       </ul>
       <div class="about-timeline-card__role">Site Manager, U.S. R&amp;D Center</div>
       <ul>
@@ -180,7 +225,7 @@ latest_posts:
       </div>
       <div class="about-timeline-card__role">Algorithm Lead, L4 Prediction &amp; Planning</div>
       <ul>
-        <li>Led the L4 prediction pre-decision algorithms for robo-taxi pilots, improving motion forecasting in complex urban scenes.</li>
+        <li>Led the L4 prediction and pre-decision algorithms for robo-taxi pilots, improving motion forecasting in complex urban scenes.</li>
         <li>Shipped planning-and-control modules and deep-learning onboard components for autonomous fleets in Beijing and Guangzhou.</li>
       </ul>
     </article>
@@ -192,7 +237,7 @@ latest_posts:
 <section class="about-section">
   <div class="about-section__header">
     <div>
-      <h2>Patents &amp; Service</h2>
+      <h2>Patents, Service &amp; Community</h2>
       <p>Research service and technology transfer beyond the production stack.</p>
     </div>
   </div>
@@ -208,7 +253,7 @@ latest_posts:
     </article>
     <article class="about-highlight-card">
       <h3>Community</h3>
-      <p>Organizer of the CVPR 2023 Autonomous Driving Workshop and frequent speaker on VLA deployment in production.</p>
+      <p>Livis Day keynote speaker, organizer of the CVPR 2023 Autonomous Driving Workshop, and frequent speaker on VLA deployment in production.</p>
     </article>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Refreshes the English homepage positioning to reflect Kun Zhan's current leadership of Li Auto foundation models and autonomous driving.
- Adds Mach VLA and Mach Mind-Pro / Mach Mind-Edge to the title, SEO metadata, hero, About Me, highlights, milestones, research interests, and work experience sections.
- Adds a Recent Milestones section for the Livis Day keynote, Mach VLA launch, and Mach Mind release.
- Updates research interests toward physical-world foundation models, agentic LLM/VLM systems, AI systems/chips, simulation/data engines, and embodied AI.

## Notes
- The role update is based on Kun Zhan's latest provided bio direction.
- Public reference links added in-page:
  - Livis Day replay: https://www.youtube.com/watch?v=E8DX3SZcUfA
  - Mach VLA launch coverage: https://www.ithome.com/0/964/508.htm
  - Mach Mind coverage: https://finance.sina.com.cn/tech/shenji/2026-06-16/doc-inicqhiw6274956.shtml

## Testing
- Not run locally; content-only Markdown/Liquid update to `_pages/about.md`.