### PR TITLE
Fix Google Scholar citation metric fallback

### DIFF
--- a/bin/update_scholar.py
+++ b/bin/update_scholar.py
@@ -57,6 +57,7 @@ FIELD_ORDER = [
 ]
 DETAIL_FETCH_FAILURES = 0
 DETAIL_FETCH_DISABLED = False
+CITATION_FRESH_FIELD = "_citation_fresh"
 
 
 class ScholarFetchError(RuntimeError):
@@ -176,8 +177,12 @@ def fetch_publication_details(scholar_id: str, article_id: str) -> dict[str, int
     html_text = http_get(SCHOLAR_DETAIL_URL.format(scholar_id=scholar_id, article_id=article_id))
     ensure_not_blocked(html_text)
 
+    if "gsc_oci_title" not in html_text:
+        raise ScholarFetchError("Unexpected Scholar publication detail response")
+
     details: dict[str, int | str] = {
-        "citation_count": parse_citation_count(html_text),
+        # Scholar omits the "Cited by" text for uncited publications.
+        "citation_count": parse_citation_count(html_text) or 0,
         "external_url": extract_title_link_from_html(html_text),
         "pdf_url": extract_pdf_link_from_html(html_text),
     }
@@ -853,6 +858,7 @@ def build_publication_record(
     scholar_url = scholar_citation_url(scholar_id, article_id) if article_id else fields.get("html", "").strip()
     details: dict[str, int | str] = {}
     citation_count = parse_optional_int(fields.get("citation_count"))
+    citation_is_fresh = citation_count is not None
     external_url = preferred_external_url(fields, scholar_url)
     pdf_url = preferred_pdf_url(fields)
     preview_image = preferred_preview_image(fields)
@@ -869,13 +875,15 @@ def build_publication_record(
             DETAIL_FETCH_FAILURES += 1
             if isinstance(error, ScholarFetchError) or DETAIL_FETCH_FAILURES >= MAX_DETAIL_FETCH_FAILURES:
                 DETAIL_FETCH_DISABLED = True
+        else:
+            fresh_citation_count = parse_optional_int(details.get("citation_count"))
+            if fresh_citation_count is not None:
+                citation_count = fresh_citation_count
+                citation_is_fresh = True
 
     note = fields.get("note", "").strip()
     external_url = str(details.get("external_url") or "").strip() or external_url
     pdf_url = str(details.get("pdf_url") or "").strip() or pdf_url
-    citation_count = details.get("citation_count") or citation_count
-    if citation_count is None:
-        citation_count = None
 
     if previous_record:
         if citation_count is None:
@@ -899,6 +907,49 @@ def build_publication_record(
         "arxiv": fields.get("arxiv", "").strip(),
         "preview_image": preview_image,
         "google_scholar_id": article_id,
+        CITATION_FRESH_FIELD: citation_is_fresh,
+    }
+
+
+def derive_citation_metrics(publications: list[dict]) -> dict[str, int]:
+    if not publications:
+        raise ScholarFetchError("Cannot derive Scholar metrics without publications")
+
+    stale_publications = [
+        str(record.get("title") or record.get("key") or "Untitled")
+        for record in publications
+        if not record.get(CITATION_FRESH_FIELD)
+    ]
+    if stale_publications:
+        sample = ", ".join(stale_publications[:3])
+        raise ScholarFetchError(
+            f"Citation snapshot is incomplete for {len(stale_publications)} publication(s): {sample}"
+        )
+
+    citation_counts = [int(record.get("citation_count") or 0) for record in publications]
+    ranked_counts = sorted(citation_counts, reverse=True)
+    h_index = max(
+        (rank for rank, citations in enumerate(ranked_counts, start=1) if citations >= rank),
+        default=0,
+    )
+    return {
+        "citations": sum(citation_counts),
+        "h_index": h_index,
+        "i10_index": sum(citations >= 10 for citations in citation_counts),
+    }
+
+
+def fallback_profile_stats(previous_data: dict, publications: list[dict]) -> dict[str, int | str]:
+    previous_profile = previous_data.get("profile") or {}
+    previous_paper_count = parse_optional_int(previous_profile.get("papers"))
+    if previous_paper_count is None:
+        raise ScholarFetchError("Profile metrics are unavailable and no previous paper count exists")
+
+    return {
+        "papers": max(previous_paper_count, len(publications)),
+        **derive_citation_metrics(publications),
+        "metrics_source": "publication_citations",
+        "papers_source": "previous_profile",
     }
 
 
@@ -917,17 +968,31 @@ def build_scholar_data(
         publications.append(record)
 
     publications.sort(key=publication_sort_key, reverse=True)
+    citation_metrics = derive_citation_metrics(publications)
     top_publications: list[dict] = []
     for record in publications[:TOP_PUBLICATIONS_LIMIT]:
         previous_record = previous_by_key.get(record_lookup_key(record))
         enriched = dict(record)
+        enriched.pop(CITATION_FRESH_FIELD, None)
         enriched["preview_image"] = resolve_preview_image(record, previous_record)
         top_publications.append(enriched)
 
     try:
         profile = fetch_profile_stats(scholar_id)
-    except (requests.RequestException, ScholarFetchError):
-        profile = dict(previous_data.get("profile") or {})
+    except (requests.RequestException, ScholarFetchError) as error:
+        profile = fallback_profile_stats(previous_data, publications)
+        sys.stderr.write(f"Scholar profile metrics fetch failed; derived current citation metrics: {error}\n")
+    else:
+        if profile["citations"] != citation_metrics["citations"]:
+            sys.stderr.write(
+                "Scholar profile and publication citation totals differ; "
+                f"using profile total {profile['citations']} instead of {citation_metrics['citations']}\n"
+            )
+        profile["metrics_source"] = "scholar_profile"
+        profile["papers_source"] = "scholar_profile"
+
+    for record in publications:
+        record.pop(CITATION_FRESH_FIELD, None)
 
     profile["updated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -958,7 +1023,12 @@ def main() -> None:
         existing_entries,
         prefer_existing=(source == "fallback"),
     )
-    scholar_data = build_scholar_data(merged_entries, scholar_id, previous_data)
+    try:
+        scholar_data = build_scholar_data(merged_entries, scholar_id, previous_data)
+    except (requests.RequestException, ScholarFetchError) as error:
+        print(f"Failed to update Scholar metrics: {error}")
+        raise SystemExit(1) from error
+
     write_bib(merged_entries)
     write_scholar_data(scholar_data)
     print(f"Updated {len(merged_entries)} publications from {source}")

--- a/tests/test_update_scholar.py
+++ b/tests/test_update_scholar.py
@@ -187,6 +187,24 @@ def test_parse_citation_count_and_scholar_links():
     assert update_scholar.extract_pdf_link_from_html(html) == "https://example.com/paper.pdf"
 
 
+def test_fetch_publication_details_treats_missing_cited_by_as_zero(monkeypatch):
+    html = """
+    <div id="gsc_oci_title"><a class="gsc_oci_title_link" href="https://example.com/paper">Paper</a></div>
+    """
+    monkeypatch.setattr(update_scholar, "http_get", lambda url: html)
+
+    details = update_scholar.fetch_publication_details("user123", "gs123")
+
+    assert details["citation_count"] == 0
+
+
+def test_fetch_publication_details_rejects_unexpected_response(monkeypatch):
+    monkeypatch.setattr(update_scholar, "http_get", lambda url: "<html>Consent page</html>")
+
+    with pytest.raises(update_scholar.ScholarFetchError, match="Unexpected Scholar publication"):
+        update_scholar.fetch_publication_details("user123", "gs123")
+
+
 def test_merge_entries_prefers_existing_fields_when_requested():
     fetched = [
         make_entry(
@@ -374,6 +392,79 @@ def test_build_scholar_data_limits_top_publications_to_ten(monkeypatch):
     assert scholar_data["top_publications"][-1]["title"] == "Paper 2"
 
 
+def test_build_scholar_data_derives_current_metrics_when_profile_fetch_fails(monkeypatch):
+    entries = [
+        make_entry(
+            "paper-high",
+            title="Paper High",
+            author="Author",
+            year="2024",
+            html="https://example.com/high",
+            scholar_id="gs-high",
+            citation_count=12,
+        ),
+        make_entry(
+            "paper-low",
+            title="Paper Low",
+            author="Author",
+            year="2023",
+            html="https://example.com/low",
+            scholar_id="gs-low",
+            citation_count=1,
+        ),
+    ]
+    previous_data = {"profile": {"papers": 3, "citations": 8, "h_index": 1, "i10_index": 0}}
+
+    monkeypatch.setattr(update_scholar, "fetch_publication_details", lambda scholar_id, article_id: {})
+    monkeypatch.setattr(
+        update_scholar,
+        "fetch_profile_stats",
+        lambda scholar_id: (_ for _ in ()).throw(update_scholar.ScholarFetchError("blocked")),
+    )
+    monkeypatch.setattr(update_scholar, "resolve_preview_image", lambda record, previous: "")
+
+    scholar_data = update_scholar.build_scholar_data(entries, "user123", previous_data)
+
+    assert scholar_data["profile"] | {"updated_at": "<ignored>"} == {
+        "papers": 3,
+        "citations": 13,
+        "h_index": 1,
+        "i10_index": 1,
+        "metrics_source": "publication_citations",
+        "papers_source": "previous_profile",
+        "updated_at": "<ignored>",
+    }
+    assert scholar_data["profile"]["updated_at"].endswith("Z")
+    assert update_scholar.CITATION_FRESH_FIELD not in scholar_data["publications"][0]
+
+
+def test_build_scholar_data_rejects_incomplete_citation_snapshot(monkeypatch):
+    entries = [
+        make_entry(
+            "paper",
+            title="Paper",
+            author="Author",
+            year="2024",
+            html="https://example.com/paper",
+            scholar_id="gs-paper",
+        )
+    ]
+    previous_data = {
+        "profile": {"papers": 1, "citations": 9, "h_index": 1, "i10_index": 0},
+        "publications": [{"google_scholar_id": "gs-paper", "citation_count": 9}],
+    }
+
+    monkeypatch.setattr(
+        update_scholar,
+        "fetch_publication_details",
+        lambda scholar_id, article_id: (_ for _ in ()).throw(update_scholar.ScholarFetchError("blocked")),
+    )
+    monkeypatch.setattr(update_scholar, "resolve_preview_image", lambda record, previous: "")
+
+    with pytest.raises(update_scholar.ScholarFetchError, match="Citation snapshot is incomplete"):
+        update_scholar.build_scholar_data(entries, "user123", previous_data)
+
+
 def test_write_bib_writes_expected_bibliography(tmp_path, monkeypatch):
     bib_file = tmp_path / "papers.bib"
     monkeypatch.setattr(update_scholar, "BIB_FILE", bib_file)
@@ -421,6 +512,41 @@ def test_main_exits_when_scholar_id_is_missing(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert exc_info.value.code == 1
     assert "No scholar_userid found" in captured.out
+
+
+def test_main_exits_without_writing_when_metrics_are_incomplete(monkeypatch, capsys):
+    entries = [
+        make_entry(
+            "paper",
+            title="Paper",
+            author="Author",
+            year="2024",
+            html="https://example.com/paper",
+            scholar_id="gs-paper",
+        )
+    ]
+    writes = []
+
+    monkeypatch.setattr(update_scholar, "read_scholar_id", lambda: "scholar-123")
+    monkeypatch.setattr(update_scholar, "read_existing_scholar_data", lambda: {})
+    monkeypatch.setattr(update_scholar, "parse_existing_bib", lambda: [])
+    monkeypatch.setattr(update_scholar, "load_publications", lambda scholar_id: ("scholar", entries))
+    monkeypatch.setattr(
+        update_scholar,
+        "build_scholar_data",
+        lambda entries, scholar_id, previous_data: (_ for _ in ()).throw(
+            update_scholar.ScholarFetchError("Citation snapshot is incomplete")
+        ),
+    )
+    monkeypatch.setattr(update_scholar, "write_bib", lambda entries: writes.append("bib"))
+    monkeypatch.setattr(update_scholar, "write_scholar_data", lambda data: writes.append("data"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        update_scholar.main()
+
+    assert exc_info.value.code == 1
+    assert writes == []
+    assert "Failed to update Scholar metrics: Citation snapshot is incomplete" in capsys.readouterr().out
 
 
 def test_main_loads_merges_and_writes_outputs(monkeypatch, capsys):


### PR DESCRIPTION
## What changed

- derive total citations, h-index, and i10-index from the current per-publication citation snapshot when the Scholar profile metrics request is blocked
- treat a valid Scholar detail page without a `Cited by` marker as zero citations
- reject consent or unexpected detail responses
- stop the update before writing files, opening an update PR, or sending review email when any citation value is stale or incomplete
- record the metric source in generated Scholar data for auditability

## Root cause

The aggregate profile request could fail while individual publication requests succeeded. The updater silently copied the previous profile total (1941) and refreshed its timestamp, even though the current per-publication counts summed to 2068.

## Validation

- `30 passed`
- `npx prettier . --check`
- `git diff --check`

PR #18 contains the stale aggregate and should not be approved.