### PR TITLE
Use SerpAPI for reliable Scholar metrics

### DIFF
--- a/.github/workflows/update-scholar.yml
+++ b/.github/workflows/update-scholar.yml
@@ -23,6 +23,7 @@ concurrency:
 
 env:
   PROFILE_UPDATE_EMAIL: ${{ vars.PROFILE_UPDATE_EMAIL || 'zk_1028@aliyun.com' }}
+  SERPAPI_KEY: ${{ secrets.SERPAPI_KEY }}
   SMTP_FROM: ${{ secrets.SMTP_FROM }}
   SMTP_HOST: ${{ secrets.SMTP_HOST }}
   SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}

--- a/bin/update_scholar.py
+++ b/bin/update_scholar.py
@@ -26,6 +26,9 @@ SCHOLAR_DATA_FILE = Path("_data/scholar.yml")
 PREVIEW_IMAGE_DIR = Path("assets/img/publication_preview")
 TOP_PUBLICATIONS_LIMIT = 10
 MAX_DETAIL_FETCH_FAILURES = 3
+SERPAPI_ENDPOINT = "https://serpapi.com/search.json"
+SERPAPI_PAGE_SIZE = 100
+SERPAPI_MAX_PAGES = 10
 
 SCHOLAR_URL = (
     "https://r.jina.ai/http://scholar.google.com/citations"
@@ -165,6 +168,123 @@ def fetch_publications_fallback() -> str:
     if not PUBLICATIONS_FALLBACK_URL:
         raise ScholarFetchError("No publications fallback URL configured")
     return http_get(PUBLICATIONS_FALLBACK_URL)
+
+
+def fetch_serpapi_page(scholar_id: str, api_key: str, start: int) -> dict:
+    try:
+        response = requests.get(
+            SERPAPI_ENDPOINT,
+            params={
+                "engine": "google_scholar_author",
+                "author_id": scholar_id,
+                "hl": "en",
+                "sort": "pubdate",
+                "num": SERPAPI_PAGE_SIZE,
+                "start": start,
+                "api_key": api_key,
+            },
+            timeout=REQUEST_TIMEOUT,
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as error:
+        raise ScholarFetchError(f"SerpAPI request failed: {type(error).__name__}") from error
+
+    if not isinstance(payload, dict):
+        raise ScholarFetchError("SerpAPI returned an unexpected response")
+    if payload.get("error"):
+        raise ScholarFetchError("SerpAPI returned an error")
+
+    status = str((payload.get("search_metadata") or {}).get("status") or "")
+    if status and status != "Success":
+        raise ScholarFetchError(f"SerpAPI search did not complete successfully: {status}")
+    return payload
+
+
+def parse_serpapi_articles(payload: dict) -> list[BibEntry]:
+    publications: list[BibEntry] = []
+    for article in payload.get("articles") or []:
+        title = normalize_text(str(article.get("title") or ""))
+        citation_id = str(article.get("citation_id") or "").strip()
+        link = str(article.get("link") or "").strip()
+        article_id = citation_id.split(":", 1)[1] if ":" in citation_id else extract_scholar_id(link)
+        if not title or not article_id:
+            raise ScholarFetchError("SerpAPI article is missing a title or citation ID")
+
+        publication = normalize_text(str(article.get("publication") or ""))
+        year = str(article.get("year") or extract_year(publication)).strip()
+        citation_count = parse_optional_int((article.get("cited_by") or {}).get("value")) or 0
+        fields = {
+            "title": title,
+            "author": normalize_authors(str(article.get("authors") or "")),
+            "year": year,
+            "html": link or scholar_citation_url(citation_id.split(":", 1)[0], article_id),
+            "google_scholar_id": article_id,
+            "citation_count": str(citation_count),
+        }
+        note = normalize_venue(publication, year)
+        if note:
+            fields["note"] = note
+
+        publications.append(
+            BibEntry(
+                entry_type="misc",
+                key="",
+                fields=fields,
+                field_order=FIELD_ORDER.copy(),
+            )
+        )
+    return publications
+
+
+def parse_serpapi_profile_stats(payload: dict, paper_count: int) -> dict[str, int | str]:
+    metric_rows = (payload.get("cited_by") or {}).get("table") or []
+
+    def metric_value(name: str) -> int:
+        for row in metric_rows:
+            metric = row.get(name)
+            if isinstance(metric, dict):
+                value = parse_optional_int(metric.get("all"))
+                if value is not None:
+                    return value
+        raise ScholarFetchError(f"SerpAPI response is missing profile metric: {name}")
+
+    return {
+        "papers": paper_count,
+        "citations": metric_value("citations"),
+        "h_index": metric_value("h_index"),
+        "i10_index": metric_value("i10_index"),
+        "metrics_source": "serpapi",
+        "papers_source": "serpapi",
+    }
+
+
+def fetch_serpapi_snapshot(scholar_id: str, api_key: str) -> tuple[list[BibEntry], dict[str, int | str]]:
+    publications: list[BibEntry] = []
+    first_payload: dict | None = None
+    start = 0
+
+    for _ in range(SERPAPI_MAX_PAGES):
+        payload = fetch_serpapi_page(scholar_id, api_key, start)
+        if first_payload is None:
+            first_payload = payload
+
+        page_publications = parse_serpapi_articles(payload)
+        publications.extend(page_publications)
+        next_page = (payload.get("serpapi_pagination") or {}).get("next")
+        if not next_page:
+            break
+        if not page_publications:
+            raise ScholarFetchError("SerpAPI pagination did not advance")
+        start += len(page_publications)
+    else:
+        raise ScholarFetchError("SerpAPI pagination exceeded the safety limit")
+
+    if first_payload is None or not publications:
+        raise ScholarFetchError("SerpAPI returned no Scholar publications")
+    profile = parse_serpapi_profile_stats(first_payload, len(publications))
+    return publications, profile
 
 
 def fetch_profile_stats(scholar_id: str) -> dict[str, int | str]:
@@ -665,6 +785,19 @@ def load_publications(scholar_id: str) -> tuple[str, list[BibEntry]]:
         return "fallback", publications
 
 
+def load_scholar_snapshot(scholar_id: str) -> tuple[str, list[BibEntry], dict[str, int | str] | None]:
+    serpapi_key = os.getenv("SERPAPI_KEY", "").strip()
+    if serpapi_key:
+        try:
+            publications, profile = fetch_serpapi_snapshot(scholar_id, serpapi_key)
+            return "serpapi", publications, profile
+        except ScholarFetchError as error:
+            sys.stderr.write(f"SerpAPI Scholar fetch failed; trying direct sources: {error}\n")
+
+    source, publications = load_publications(scholar_id)
+    return source, publications, None
+
+
 def entry_lookup_key(fields: dict[str, str]) -> str:
     scholar_id = fields.get("google_scholar_id", "").strip()
     if scholar_id:
@@ -863,9 +996,7 @@ def build_publication_record(
     pdf_url = preferred_pdf_url(fields)
     preview_image = preferred_preview_image(fields)
 
-    needs_detail_fetch = article_id and not DETAIL_FETCH_DISABLED and (
-        citation_count is None or external_url == scholar_url or not pdf_url
-    )
+    needs_detail_fetch = article_id and not DETAIL_FETCH_DISABLED and citation_count is None
 
     if needs_detail_fetch:
         try:
@@ -957,6 +1088,7 @@ def build_scholar_data(
     entries: list[BibEntry],
     scholar_id: str,
     previous_data: dict | None = None,
+    profile_stats: dict[str, int | str] | None = None,
 ) -> dict:
     previous_data = previous_data or {}
     previous_publications = previous_data.get("publications") or []
@@ -977,19 +1109,23 @@ def build_scholar_data(
         enriched["preview_image"] = resolve_preview_image(record, previous_record)
         top_publications.append(enriched)
 
-    try:
-        profile = fetch_profile_stats(scholar_id)
-    except (requests.RequestException, ScholarFetchError) as error:
-        profile = fallback_profile_stats(previous_data, publications)
-        sys.stderr.write(f"Scholar profile metrics fetch failed; derived current citation metrics: {error}\n")
+    if profile_stats is not None:
+        profile = dict(profile_stats)
     else:
-        if profile["citations"] != citation_metrics["citations"]:
-            sys.stderr.write(
-                "Scholar profile and publication citation totals differ; "
-                f"using profile total {profile['citations']} instead of {citation_metrics['citations']}\n"
-            )
-        profile["metrics_source"] = "scholar_profile"
-        profile["papers_source"] = "scholar_profile"
+        try:
+            profile = fetch_profile_stats(scholar_id)
+        except (requests.RequestException, ScholarFetchError) as error:
+            profile = fallback_profile_stats(previous_data, publications)
+            sys.stderr.write(f"Scholar profile metrics fetch failed; derived current citation metrics: {error}\n")
+        else:
+            profile["metrics_source"] = "scholar_profile"
+            profile["papers_source"] = "scholar_profile"
+
+    if profile["citations"] != citation_metrics["citations"]:
+        sys.stderr.write(
+            "Scholar profile and publication citation totals differ; "
+            f"using profile total {profile['citations']} instead of {citation_metrics['citations']}\n"
+        )
 
     for record in publications:
         record.pop(CITATION_FRESH_FIELD, None)
@@ -1013,7 +1149,7 @@ def main() -> None:
     existing_entries = parse_existing_bib()
 
     try:
-        source, fetched_entries = load_publications(scholar_id)
+        source, fetched_entries, profile_stats = load_scholar_snapshot(scholar_id)
     except (requests.RequestException, ScholarFetchError) as error:
         print(f"Failed to update Scholar publications: {error}")
         raise SystemExit(1) from error
@@ -1024,7 +1160,7 @@ def main() -> None:
         prefer_existing=(source == "fallback"),
     )
     try:
-        scholar_data = build_scholar_data(merged_entries, scholar_id, previous_data)
+        scholar_data = build_scholar_data(merged_entries, scholar_id, previous_data, profile_stats)
     except (requests.RequestException, ScholarFetchError) as error:
         print(f"Failed to update Scholar metrics: {error}")
         raise SystemExit(1) from error

--- a/tests/test_profile_update_report.py
+++ b/tests/test_profile_update_report.py
@@ -84,5 +84,6 @@ def test_workflow_formats_only_generated_scholar_data():
 
     assert "python bin/update_scholar.py" in workflow
     assert "npx prettier _data/scholar.yml --write" in workflow
+    assert "SERPAPI_KEY: ${{ secrets.SERPAPI_KEY }}" in workflow
     assert "update_progress" not in workflow
     assert "_data/progress.yml" not in workflow

--- a/tests/test_update_scholar.py
+++ b/tests/test_update_scholar.py
@@ -94,6 +94,177 @@ def test_http_get_returns_response_text(monkeypatch):
     assert "Mozilla/5.0" in calls["headers"]["User-Agent"]
 
 
+def make_serpapi_payload(articles, *, citations=13, h_index=1, i10_index=1, next_page=""):
+    payload = {
+        "search_metadata": {"status": "Success"},
+        "articles": articles,
+        "cited_by": {
+            "table": [
+                {"citations": {"all": citations}},
+                {"h_index": {"all": h_index}},
+                {"i10_index": {"all": i10_index}},
+            ]
+        },
+    }
+    if next_page:
+        payload["serpapi_pagination"] = {"next": next_page}
+    return payload
+
+
+def make_serpapi_article(article_id, title, citations, year="2024"):
+    return {
+        "title": title,
+        "link": (
+            "https://scholar.google.com/citations?view_op=view_citation"
+            f"&user=user123&citation_for_view=user123:{article_id}"
+        ),
+        "citation_id": f"user123:{article_id}",
+        "authors": "Alice Smith, Bob Jones",
+        "publication": f"Journal of Testing, {year}",
+        "cited_by": {"value": citations},
+        "year": year,
+    }
+
+
+def test_fetch_serpapi_page_uses_structured_params(monkeypatch):
+    calls = {}
+    payload = make_serpapi_payload([])
+
+    class DummyResponse:
+        def raise_for_status(self):
+            calls["raised"] = True
+
+        def json(self):
+            return payload
+
+    def fake_get(url, params, timeout, headers):
+        calls.update({"url": url, "params": params, "timeout": timeout, "headers": headers})
+        return DummyResponse()
+
+    monkeypatch.setattr(update_scholar.requests, "get", fake_get)
+
+    result = update_scholar.fetch_serpapi_page("user123", "secret-key", 20)
+
+    assert result == payload
+    assert calls["url"] == update_scholar.SERPAPI_ENDPOINT
+    assert calls["params"] == {
+        "engine": "google_scholar_author",
+        "author_id": "user123",
+        "hl": "en",
+        "sort": "pubdate",
+        "num": update_scholar.SERPAPI_PAGE_SIZE,
+        "start": 20,
+        "api_key": "secret-key",
+    }
+    assert calls["raised"] is True
+
+
+def test_fetch_serpapi_page_does_not_expose_api_key_in_errors(monkeypatch):
+    monkeypatch.setattr(
+        update_scholar.requests,
+        "get",
+        lambda *args, **kwargs: (_ for _ in ()).throw(update_scholar.requests.Timeout("secret-key")),
+    )
+
+    with pytest.raises(update_scholar.ScholarFetchError) as exc_info:
+        update_scholar.fetch_serpapi_page("user123", "secret-key", 0)
+
+    assert "secret-key" not in str(exc_info.value)
+
+
+def test_fetch_serpapi_snapshot_parses_articles_metrics_and_pagination(monkeypatch):
+    first_page = make_serpapi_payload(
+        [make_serpapi_article("first", "First Paper", 12)],
+        citations=13,
+        next_page="https://serpapi.com/search.json?start=1",
+    )
+    second_page = make_serpapi_payload(
+        [make_serpapi_article("second", "Second Paper", 1, year="2023")],
+        citations=13,
+    )
+    calls = []
+
+    def fake_fetch(scholar_id, api_key, start):
+        calls.append((scholar_id, api_key, start))
+        return first_page if start == 0 else second_page
+
+    monkeypatch.setattr(update_scholar, "fetch_serpapi_page", fake_fetch)
+
+    publications, profile = update_scholar.fetch_serpapi_snapshot("user123", "secret-key")
+
+    assert calls == [("user123", "secret-key", 0), ("user123", "secret-key", 1)]
+    assert [entry.fields["google_scholar_id"] for entry in publications] == ["first", "second"]
+    assert [entry.fields["citation_count"] for entry in publications] == ["12", "1"]
+    assert profile == {
+        "papers": 2,
+        "citations": 13,
+        "h_index": 1,
+        "i10_index": 1,
+        "metrics_source": "serpapi",
+        "papers_source": "serpapi",
+    }
+
+
+def test_load_scholar_snapshot_prefers_configured_serpapi(monkeypatch):
+    entries = [
+        make_entry(
+            "paper",
+            title="Paper",
+            author="Author",
+            year="2024",
+            html="https://example.com/paper",
+            scholar_id="paper-id",
+        )
+    ]
+    profile = {"papers": 1, "citations": 12, "h_index": 1, "i10_index": 1}
+    calls = []
+
+    monkeypatch.setenv("SERPAPI_KEY", "secret-key")
+    monkeypatch.setattr(
+        update_scholar,
+        "fetch_serpapi_snapshot",
+        lambda scholar_id, api_key: calls.append((scholar_id, api_key)) or (entries, profile),
+    )
+    monkeypatch.setattr(
+        update_scholar,
+        "load_publications",
+        lambda scholar_id: (_ for _ in ()).throw(AssertionError("fallback should not run")),
+    )
+
+    result = update_scholar.load_scholar_snapshot("user123")
+
+    assert result == ("serpapi", entries, profile)
+    assert calls == [("user123", "secret-key")]
+
+
+def test_load_scholar_snapshot_falls_back_when_serpapi_fails(monkeypatch, capsys):
+    entries = [
+        make_entry(
+            "paper",
+            title="Paper",
+            author="Author",
+            year="2024",
+            html="https://example.com/paper",
+            scholar_id="paper-id",
+        )
+    ]
+
+    monkeypatch.setenv("SERPAPI_KEY", "secret-key")
+    monkeypatch.setattr(
+        update_scholar,
+        "fetch_serpapi_snapshot",
+        lambda scholar_id, api_key: (_ for _ in ()).throw(
+            update_scholar.ScholarFetchError("temporary provider failure")
+        ),
+    )
+    monkeypatch.setattr(update_scholar, "load_publications", lambda scholar_id: ("scholar", entries))
+
+    result = update_scholar.load_scholar_snapshot("user123")
+
+    assert result == ("scholar", entries, None)
+    assert "trying direct sources" in capsys.readouterr().err
+
+
 def test_parse_publications_from_markdown_extracts_entries_and_note():
     text = """
 ignored
@@ -438,6 +609,40 @@ def test_build_scholar_data_derives_current_metrics_when_profile_fetch_fails(mon
     assert update_scholar.CITATION_FRESH_FIELD not in scholar_data["publications"][0]
 
 
+def test_build_scholar_data_uses_supplied_serpapi_profile(monkeypatch):
+    entries = [
+        make_entry(
+            "paper",
+            title="Paper",
+            author="Author",
+            year="2024",
+            html="https://example.com/paper",
+            scholar_id="gs-paper",
+            citation_count=12,
+        )
+    ]
+    profile_stats = {
+        "papers": 1,
+        "citations": 12,
+        "h_index": 1,
+        "i10_index": 1,
+        "metrics_source": "serpapi",
+        "papers_source": "serpapi",
+    }
+
+    monkeypatch.setattr(
+        update_scholar,
+        "fetch_profile_stats",
+        lambda scholar_id: (_ for _ in ()).throw(AssertionError("direct profile fetch should be skipped")),
+    )
+    monkeypatch.setattr(update_scholar, "resolve_preview_image", lambda record, previous: "")
+
+    scholar_data = update_scholar.build_scholar_data(entries, "user123", {}, profile_stats)
+
+    assert scholar_data["profile"]["citations"] == 12
+    assert scholar_data["profile"]["metrics_source"] == "serpapi"
+
+
 def test_build_scholar_data_rejects_incomplete_citation_snapshot(monkeypatch):
     entries = [
         make_entry(
@@ -530,11 +735,15 @@ def test_main_exits_without_writing_when_metrics_are_incomplete(monkeypatch, cap
     monkeypatch.setattr(update_scholar, "read_scholar_id", lambda: "scholar-123")
     monkeypatch.setattr(update_scholar, "read_existing_scholar_data", lambda: {})
     monkeypatch.setattr(update_scholar, "parse_existing_bib", lambda: [])
-    monkeypatch.setattr(update_scholar, "load_publications", lambda scholar_id: ("scholar", entries))
+    monkeypatch.setattr(
+        update_scholar,
+        "load_scholar_snapshot",
+        lambda scholar_id: ("scholar", entries, None),
+    )
     monkeypatch.setattr(
         update_scholar,
         "build_scholar_data",
-        lambda entries, scholar_id, previous_data: (_ for _ in ()).throw(
+        lambda entries, scholar_id, previous_data, profile_stats: (_ for _ in ()).throw(
             update_scholar.ScholarFetchError("Citation snapshot is incomplete")
         ),
     )
@@ -582,8 +791,9 @@ def test_main_loads_merges_and_writes_outputs(monkeypatch, capsys):
     monkeypatch.setattr(update_scholar, "parse_existing_bib", lambda: existing_entries)
     monkeypatch.setattr(
         update_scholar,
-        "load_publications",
-        lambda scholar_id: calls.__setitem__("load_publications", scholar_id) or ("scholar", fetched_entries),
+        "load_scholar_snapshot",
+        lambda scholar_id: calls.__setitem__("load_scholar_snapshot", scholar_id)
+        or ("serpapi", fetched_entries, {"citations": 10}),
     )
     monkeypatch.setattr(
         update_scholar,
@@ -597,9 +807,9 @@ def test_main_loads_merges_and_writes_outputs(monkeypatch, capsys):
     monkeypatch.setattr(
         update_scholar,
         "build_scholar_data",
-        lambda entries, scholar_id, previous_data: calls.__setitem__(
+        lambda entries, scholar_id, previous_data, profile_stats: calls.__setitem__(
             "build_scholar_data",
-            (entries, scholar_id, previous_data),
+            (entries, scholar_id, previous_data, profile_stats),
         )
         or scholar_data,
     )
@@ -613,9 +823,14 @@ def test_main_loads_merges_and_writes_outputs(monkeypatch, capsys):
     update_scholar.main()
 
     captured = capsys.readouterr()
-    assert calls["load_publications"] == "scholar-123"
+    assert calls["load_scholar_snapshot"] == "scholar-123"
     assert calls["merge_entries"] == (fetched_entries, existing_entries, False)
-    assert calls["build_scholar_data"] == (merged_entries, "scholar-123", {"profile": {"papers": 1}})
+    assert calls["build_scholar_data"] == (
+        merged_entries,
+        "scholar-123",
+        {"profile": {"papers": 1}},
+        {"citations": 10},
+    )
     assert calls["write_bib"] == merged_entries
     assert calls["write_scholar_data"] == scholar_data
-    assert "Updated 2 publications from scholar" in captured.out
+    assert "Updated 2 publications from serpapi" in captured.out


### PR DESCRIPTION
## 更新内容

- 将 SerpAPI Google Scholar Author API 设为每周更新的首选数据源
- 同一次抓取中读取总引用、h-index、i10-index，以及每篇论文的引用数
- 支持分页，单页最多 100 篇，并设置安全上限
- SerpAPI 暂时失败时退回现有 Scholar/Jina 路径；所有来源都不可用时继续安全失败，不写入旧数据
- 对错误信息做脱敏，避免 `SERPAPI_KEY` 出现在日志中
- GitHub Actions 从 `secrets.SERPAPI_KEY` 注入密钥

## 验证

- `36 passed`
- `npx prettier . --check`
- `git diff --check`

合入后请手动运行一次 **Google Scholar Weekly Update**，确认新的审核 PR 中总引用来自 SerpAPI，且与当前 Scholar 页面一致。