### PR TITLE
Fix Scholar approval repository context

### DIFF
--- a/.github/workflows/approve-profile-update.yml
+++ b/.github/workflows/approve-profile-update.yml
@@ -44,7 +44,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           if [ "$GITHUB_ACTOR" != "$REPOSITORY_OWNER" ]; then
-            gh pr comment "$PR_NUMBER" --body "This command can only be used by the repository owner."
+            gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" --body "This command can only be used by the repository owner."
             exit 1
           fi
 
@@ -54,7 +54,7 @@ jobs:
           HEAD_REPO="$(jq -r '.head.repo.full_name' <<< "$PR_JSON")"
           HEAD_SHA="$(jq -r '.head.sha' <<< "$PR_JSON")"
           STATE="$(jq -r '.state' <<< "$PR_JSON")"
-          LABEL_OK="$(gh pr view "$PR_NUMBER" --json labels --jq 'any(.labels[]; .name == "scholar-update:emailed")')"
+          LABEL_OK="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels --jq 'any(.labels[]; .name == "scholar-update:emailed")')"
 
           if [ "$STATE" != "open" ] || [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
             echo "Candidate is not an open PR against the default branch."

--- a/tests/test_profile_update_report.py
+++ b/tests/test_profile_update_report.py
@@ -87,3 +87,15 @@ def test_workflow_formats_only_generated_scholar_data():
     assert "SERPAPI_KEY: ${{ secrets.SERPAPI_KEY }}" in workflow
     assert "update_progress" not in workflow
     assert "_data/progress.yml" not in workflow
+
+
+def test_approval_validation_scopes_pr_commands_to_repository():
+    workflow = (
+        Path(__file__).resolve().parents[1]
+        / ".github"
+        / "workflows"
+        / "approve-profile-update.yml"
+    ).read_text(encoding="utf-8")
+
+    assert 'gh pr comment "$PR_NUMBER" --repo "$REPOSITORY"' in workflow
+    assert 'gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels' in workflow


### PR DESCRIPTION
## 修复内容

- 为审批验证阶段的 `gh pr view` 明确指定当前仓库
- 同时修正非仓库所有者提示命令的仓库定位
- 新增回归测试，避免未检出仓库时再次触发 `fatal: not a git repository`

## 根因

`/approve` 工作流在 checkout 之前验证候选 PR，但 `gh pr view` 依赖当前 Git 仓库来推断目标仓库，因此验证步骤在 GitHub runner 上失败。

## 验证

- `37 passed`
- `npx prettier . --check`
- `git diff --check`

合入后，请在仍然打开的 Scholar 数据 PR #21 再评论一次精确的 `/approve`。